### PR TITLE
Pin claude-code-action to full commit SHA

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@006aaf2935208098c2b871c8233c9637db8b553d # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@006aaf2935208098c2b871c8233c9637db8b553d # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 


### PR DESCRIPTION
## Summary
- Pins `anthropics/claude-code-action` to full commit SHA (`006aaf29...`) in both workflow files
- Fixes SonarCloud code quality gate failure: "Use full commit SHA hash for this dependency"
- Retains `# v1` comment for readability

## Test plan
- [ ] Verify SonarCloud quality gate passes
- [ ] Verify Claude Code workflows still trigger correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)