### PR TITLE
Checkpoint pass-1 improvements + modernization roadmap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,3 +164,26 @@
 **Files Modified**:
 - `ConnectionStore.swift:272-274` - Removed sortDescriptors from CKQuery
 - `ConnectionStore.swift:337-338` - Added in-memory sorting after fetch completes
+
+---
+
+## Swift API Modernization (2026-06-15)
+
+Full details and per-task notes live in [`MODERNIZATION_ROADMAP.md`](MODERNIZATION_ROADMAP.md).
+Each task ships on its own branch off `Development` with its own PR. Listed in
+priority order (impact, high → low):
+
+- [ ] **1. Adopt Observation framework (`@Observable`)** — `refactor/observable-macro` — *High*
+  - `Connection` + `ConnectionStore` → `@Observable`; drop `@Published`/Combine; migrate view property wrappers
+- [ ] **2. Native async CloudKit APIs** — `refactor/cloudkit-async-apis` — *High*
+  - Replace `withCheckedContinuation` bridging with `record(for:)`, `save(_:)`, `deleteRecord(for:)`, `modifyRecordZones`, `records(matching:)`
+- [ ] **3. `Task.sleep(for:)` with `Duration`** — `refactor/task-sleep-duration` — *Medium*
+  - `ConnectionStore.swift:154`
+- [ ] **4. `@Entry` macro for environment key** — `refactor/entry-macro-environment` — *Medium*
+  - `MainView.swift:1004-1013`
+- [ ] **5. `ByteCountFormatStyle` (`.formatted`)** — `refactor/bytecount-format-style` — *Medium*
+  - `DataCounterView.swift`
+- [ ] **6. Replace `DispatchQueue.main.asyncAfter`** — `refactor/async-error-clear` — *Low*
+  - `ContentView.swift:46`
+- [ ] **7. NIO singleton event-loop group** — `refactor/nio-singleton-eventloop` — *Low (optional)*
+  - `SSHManager.swift:511` (review lifecycle before adopting)

--- a/MODERNIZATION_ROADMAP.md
+++ b/MODERNIZATION_ROADMAP.md
@@ -1,0 +1,130 @@
+# Swift API Modernization Roadmap
+
+Opportunities to adopt newer Swift / SwiftUI / Foundation / CloudKit APIs.
+Deployment target is **macOS 15.6**, so all modern APIs below are available.
+
+## Workflow
+
+- **Base branch:** `Development` (protected — never push directly).
+- Each task gets its **own branch off `Development`**, its own PR.
+- Branch naming follows the project convention (`refactor/...`).
+- Tasks are listed in priority order (impact, high → low). They are independent
+  and can be merged in any order, but if doing several at once the low-risk,
+  self-contained ones (#3, #4, #5) are the safest to start with, followed by
+  #2 and #1, then #6 and #7.
+
+| # | Task | Branch | Impact | Status |
+|---|------|--------|--------|--------|
+| 1 | Adopt Observation framework (`@Observable`) | `refactor/observable-macro` | High | Not started |
+| 2 | Native async CloudKit APIs | `refactor/cloudkit-async-apis` | High | Not started |
+| 3 | `Task.sleep(for:)` with `Duration` | `refactor/task-sleep-duration` | Medium | Not started |
+| 4 | `@Entry` macro for environment key | `refactor/entry-macro-environment` | Medium | Not started |
+| 5 | `ByteCountFormatStyle` (`.formatted`) | `refactor/bytecount-format-style` | Medium | Not started |
+| 6 | Replace `DispatchQueue.main.asyncAfter` | `refactor/async-error-clear` | Low | Not started |
+| 7 | NIO singleton event-loop group | `refactor/nio-singleton-eventloop` | Low | Not started |
+
+---
+
+## 1. Adopt the Observation framework (`@Observable`)
+**Branch:** `refactor/observable-macro` · **Impact:** High
+
+Replace `ObservableObject` + `@Published` with the `@Observable` macro (macOS 14+).
+Gives finer-grained view updates and removes the Combine dependency.
+
+- `Connection.swift:63` — `class Connection: ... ObservableObject` → `@Observable @MainActor class Connection`; drop all `@Published`; remove `import Combine` (line 3).
+- `ConnectionStore.swift:42` — convert to `@Observable`; drop `@Published` from the ~15 published properties.
+- View property-wrapper migration:
+  - `@EnvironmentObject` → `@Environment` (`MainView.swift`, `ContentView.swift`)
+  - `@ObservedObject` → plain `let` or `@Bindable` (`ConnectionRow.swift`, `DataCounterView.swift`, `ConnectionIndicatorView`, `ConnectButtonView`)
+  - `@StateObject` → `@State` (`ContentView.swift:18`, `SSH_TunnelBuilderApp.swift:5`)
+
+**Note on `SSHManager` (`SSHManager.swift:453`):** it is `@unchecked Sendable` and mutated
+off the main actor, so it is **not** a good `@Observable` fit. Its `@Published var
+lastErrorMessage` (line 469) appears unobserved by any view — drop the
+`ObservableObject`/`@Published` there rather than convert it. Also remove its
+`import Combine` (line 5) once done.
+
+**Risk:** Touches many view files; mechanical but broad. Verify previews and all
+view updates still fire after conversion.
+
+---
+
+## 2. Native async CloudKit APIs
+**Branch:** `refactor/cloudkit-async-apis` · **Impact:** High
+
+`ConnectionStore.swift` hand-wraps every CloudKit call in `withCheckedContinuation`.
+macOS 12+ provides native `async` equivalents — removes ~120 lines of bridging.
+
+| Current (manual bridge) | Modern async API |
+|---|---|
+| `createCustomZoneAsync` + `CKModifyRecordZonesOperation` (278–304) | `try await database.modifyRecordZones(saving:deleting:)` |
+| `fetchRecord` wrapper (429–441) | `try await database.record(for:)` |
+| `saveRecord` wrapper (444–456) | `try await database.save(_:)` |
+| `deleteRecord` wrapper (459–471) | `try await database.deleteRecord(for:)` |
+| `fetchConnectionsAsync` + `CKQueryOperation` (312–365) | `try await database.records(matching:inZoneWith:desiredKeys:resultsLimit:)` → `(matchResults, queryCursor)`, paged via `records(continuingMatchFrom:)` |
+
+The three private wrappers (`fetchRecord`, `saveRecord`, `deleteRecord`) and the
+`CloudKitOperationError` enum can be deleted entirely.
+
+**Risk:** Preserve existing behavior — in-memory sorting after fetch
+(`ConnectionStore.swift:395`), per-record error logging, and the `desiredKeys`
+list. Test against the real CloudKit container.
+
+---
+
+## 3. `Task.sleep(for:)` with `Duration`
+**Branch:** `refactor/task-sleep-duration` · **Impact:** Medium
+
+- `ConnectionStore.swift:154` — `Task.sleep(nanoseconds: loadingFallbackSeconds * 1_000_000_000)` → `Task.sleep(for: .seconds(loadingFallbackSeconds))`.
+- Simplify `loadingFallbackSeconds` (line 140) from `UInt64` to a plain `Int`.
+
+**Risk:** Trivial.
+
+---
+
+## 4. `@Entry` macro for the custom environment key
+**Branch:** `refactor/entry-macro-environment` · **Impact:** Medium
+
+- `MainView.swift:1004–1013` — replace the `ConnectionEnvironmentKey` struct +
+  `EnvironmentValues` extension with:
+  ```swift
+  extension EnvironmentValues {
+      @Entry var connection: Connection?
+  }
+  ```
+- Also fixes the latent Swift 6 mutable-static-`defaultValue` issue (line 1005).
+
+**Risk:** Trivial. Confirm the `connection` environment value has no other readers.
+
+---
+
+## 5. `ByteCountFormatStyle` instead of `ByteCountFormatter`
+**Branch:** `refactor/bytecount-format-style` · **Impact:** Medium
+
+- `DataCounterView.swift:18-19` — use `connection.bytesSent.formatted(.byteCount(style: .file))`.
+- Remove the `byteCountFormatter` computed property (lines 31-35).
+
+**Risk:** Trivial. Verify formatted output matches the previous `.file` style.
+
+---
+
+## 6. Replace `DispatchQueue.main.asyncAfter`
+**Branch:** `refactor/async-error-clear` · **Impact:** Low
+
+- `ContentView.swift:46` — `DispatchQueue.main.asyncAfter(deadline: .now() + 0.1)`
+  → `Task { try? await Task.sleep(for: .milliseconds(100)); ... }` (view is already `@MainActor`).
+
+**Risk:** Trivial.
+
+---
+
+## 7. NIO singleton event-loop group
+**Branch:** `refactor/nio-singleton-eventloop` · **Impact:** Low (optional)
+
+- `SSHManager.swift:511` creates and later shuts down a fresh
+  `MultiThreadedEventLoopGroup` per connection. Consider
+  `MultiThreadedEventLoopGroup.singleton` / `NIOSingletons` to avoid per-connection
+  thread spin-up/teardown.
+
+**Risk:** Behavioral change — the shared singleton must **not** be shut down in
+`shutdown()` (`SSHManager.swift:804-811`). Review lifecycle carefully before adopting.

--- a/SSH TunnelBuilder.xcodeproj/project.pbxproj
+++ b/SSH TunnelBuilder.xcodeproj/project.pbxproj
@@ -7,29 +7,21 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		F422C57A29E46B2B007306BC /* DataCounterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F422C57929E46B2B007306BC /* DataCounterView.swift */; };
-		F45BB0992EE4274A000B4FA8 /* NIO in Frameworks */ = {isa = PBXBuildFile; productRef = F45BB0982EE4274A000B4FA8 /* NIO */; };
-		F45BB09B2EE4274A000B4FA8 /* NIOConcurrencyHelpers in Frameworks */ = {isa = PBXBuildFile; productRef = F45BB09A2EE4274A000B4FA8 /* NIOConcurrencyHelpers */; };
-		F45BB09D2EE4274A000B4FA8 /* NIOCore in Frameworks */ = {isa = PBXBuildFile; productRef = F45BB09C2EE4274A000B4FA8 /* NIOCore */; };
-		F45BB09F2EE4274A000B4FA8 /* NIOEmbedded in Frameworks */ = {isa = PBXBuildFile; productRef = F45BB09E2EE4274A000B4FA8 /* NIOEmbedded */; };
-		F45BB0A32EE4274A000B4FA8 /* NIOTLS in Frameworks */ = {isa = PBXBuildFile; productRef = F45BB0A22EE4274A000B4FA8 /* NIOTLS */; };
-		F4700F8129D7669E0069DC6D /* NavigationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4700F8029D7669E0069DC6D /* NavigationView.swift */; };
-		F4700F8329D7670D0069DC6D /* MainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4700F8229D7670D0069DC6D /* MainView.swift */; };
-		F4700F8529D768E20069DC6D /* ConnectionRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4700F8429D768E20069DC6D /* ConnectionRow.swift */; };
-		F49EBCB229D367A500A43775 /* ConnectionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = F49EBCB129D367A500A43775 /* ConnectionStore.swift */; };
-		F49EBCB429D367A900A43775 /* Connection.swift in Sources */ = {isa = PBXBuildFile; fileRef = F49EBCB329D367A900A43775 /* Connection.swift */; };
-		F4A368C02EE9964400762D9D /* PEMDecryptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4A368BF2EE9943A00762D9D /* PEMDecryptor.swift */; };
-		F4A6A56A2EF2C73E000C2B1C /* NIOSSH in Frameworks */ = {isa = PBXBuildFile; productRef = F4A6A5692EF2C73E000C2B1C /* NIOSSH */; };
-		F4AA684F2F3533540065E097 /* SampleData.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4AA684E2F3533540065E097 /* SampleData.swift */; };
-		F4AA68512F3533F80065E097 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4AA68502F3533F80065E097 /* Logger.swift */; };
-		F4AA685E2F35400A0065E097 /* SSHTunnelError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4AA685C2F35400A0065E097 /* SSHTunnelError.swift */; };
-		F4AA68602F35400A0065E097 /* SSHTunnelError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4AA685C2F35400A0065E097 /* SSHTunnelError.swift */; };
-		F4ABBF5827DFDF730097436A /* SSH_TunnelBuilderApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4ABBF5727DFDF730097436A /* SSH_TunnelBuilderApp.swift */; };
-		F4ABBF5A27DFDF730097436A /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4ABBF5927DFDF730097436A /* ContentView.swift */; };
-		F4ABBF5C27DFDF740097436A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F4ABBF5B27DFDF740097436A /* Assets.xcassets */; };
-		F4ABBF5F27DFDF740097436A /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F4ABBF5E27DFDF740097436A /* Preview Assets.xcassets */; };
-		F4B4CA462EBBCA31003F7C53 /* SSHManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4B4CA452EBBCA31003F7C53 /* SSHManager.swift */; };
-		F4B4CA4B2EBBD995003F7C53 /* KeychainService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4B4CA4A2EBBD995003F7C53 /* KeychainService.swift */; };
+		F47CCD3B2FDB588600BBECDF /* NIOSSH in Frameworks */ = {isa = PBXBuildFile; productRef = F47CCD3A2FDB588600BBECDF /* NIOSSH */; };
+		F47CCD3E2FDB592A00BBECDF /* NIO in Frameworks */ = {isa = PBXBuildFile; productRef = F47CCD3D2FDB592A00BBECDF /* NIO */; };
+		F47CCD402FDB592A00BBECDF /* NIOConcurrencyHelpers in Frameworks */ = {isa = PBXBuildFile; productRef = F47CCD3F2FDB592A00BBECDF /* NIOConcurrencyHelpers */; };
+		F47CCD422FDB592A00BBECDF /* NIOCore in Frameworks */ = {isa = PBXBuildFile; productRef = F47CCD412FDB592A00BBECDF /* NIOCore */; };
+		F47CCD442FDB592A00BBECDF /* NIOEmbedded in Frameworks */ = {isa = PBXBuildFile; productRef = F47CCD432FDB592A00BBECDF /* NIOEmbedded */; };
+		F47CCD462FDB592A00BBECDF /* NIOFoundationCompat in Frameworks */ = {isa = PBXBuildFile; productRef = F47CCD452FDB592A00BBECDF /* NIOFoundationCompat */; };
+		F47CCD482FDB592A00BBECDF /* NIOFoundationEssentialsCompat in Frameworks */ = {isa = PBXBuildFile; productRef = F47CCD472FDB592A00BBECDF /* NIOFoundationEssentialsCompat */; };
+		F47CCD4A2FDB592A00BBECDF /* NIOHTTP1 in Frameworks */ = {isa = PBXBuildFile; productRef = F47CCD492FDB592A00BBECDF /* NIOHTTP1 */; };
+		F47CCD4C2FDB592A00BBECDF /* NIOPosix in Frameworks */ = {isa = PBXBuildFile; productRef = F47CCD4B2FDB592A00BBECDF /* NIOPosix */; };
+		F47CCD4E2FDB592A00BBECDF /* NIOTLS in Frameworks */ = {isa = PBXBuildFile; productRef = F47CCD4D2FDB592A00BBECDF /* NIOTLS */; };
+		F47CCD502FDB592A00BBECDF /* NIOTestUtils in Frameworks */ = {isa = PBXBuildFile; productRef = F47CCD4F2FDB592A00BBECDF /* NIOTestUtils */; };
+		F47CCD522FDB592A00BBECDF /* NIOWebSocket in Frameworks */ = {isa = PBXBuildFile; productRef = F47CCD512FDB592A00BBECDF /* NIOWebSocket */; };
+		F47CCD542FDB592A00BBECDF /* _NIOConcurrency in Frameworks */ = {isa = PBXBuildFile; productRef = F47CCD532FDB592A00BBECDF /* _NIOConcurrency */; };
+		F47CCD562FDB592A00BBECDF /* _NIOFileSystem in Frameworks */ = {isa = PBXBuildFile; productRef = F47CCD552FDB592A00BBECDF /* _NIOFileSystem */; };
+		F47CCD582FDB592A00BBECDF /* _NIOFileSystemFoundationCompat in Frameworks */ = {isa = PBXBuildFile; productRef = F47CCD572FDB592A00BBECDF /* _NIOFileSystemFoundationCompat */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -43,32 +35,22 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		F422C57929E46B2B007306BC /* DataCounterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataCounterView.swift; sourceTree = "<group>"; };
 		F45BB0882EE41928000B4FA8 /* CryptoKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CryptoKit.framework; path = System/Library/Frameworks/CryptoKit.framework; sourceTree = SDKROOT; };
-		F4700F8029D7669E0069DC6D /* NavigationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationView.swift; sourceTree = "<group>"; };
-		F4700F8229D7670D0069DC6D /* MainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainView.swift; sourceTree = "<group>"; };
-		F4700F8429D768E20069DC6D /* ConnectionRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionRow.swift; sourceTree = "<group>"; };
-		F49EBCB129D367A500A43775 /* ConnectionStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionStore.swift; sourceTree = "<group>"; };
-		F49EBCB329D367A900A43775 /* Connection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Connection.swift; sourceTree = "<group>"; };
-		F4A368BF2EE9943A00762D9D /* PEMDecryptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PEMDecryptor.swift; sourceTree = "<group>"; };
-		F4AA684E2F3533540065E097 /* SampleData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleData.swift; sourceTree = "<group>"; };
-		F4AA68502F3533F80065E097 /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
-		F4AA685C2F35400A0065E097 /* SSHTunnelError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHTunnelError.swift; sourceTree = "<group>"; };
 		F4ABBF5427DFDF730097436A /* SSH TunnelBuilder.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "SSH TunnelBuilder.app"; sourceTree = BUILT_PRODUCTS_DIR; };
-		F4ABBF5727DFDF730097436A /* SSH_TunnelBuilderApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSH_TunnelBuilderApp.swift; sourceTree = "<group>"; };
-		F4ABBF5927DFDF730097436A /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
-		F4ABBF5B27DFDF740097436A /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
-		F4ABBF5E27DFDF740097436A /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
-		F4ABBF6527DFDF740097436A /* SSH_TunnelBuilder.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SSH_TunnelBuilder.entitlements; sourceTree = "<group>"; };
 		F4B4CA422EBBC20E003F7C53 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		F4B4CA432EBBC211003F7C53 /* NOTICE.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = NOTICE.txt; sourceTree = "<group>"; };
 		F4B4CA442EBBC2AC003F7C53 /* LICENSE.TXT */ = {isa = PBXFileReference; lastKnownFileType = text; path = LICENSE.TXT; sourceTree = "<group>"; };
-		F4B4CA452EBBCA31003F7C53 /* SSHManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHManager.swift; sourceTree = "<group>"; };
-		F4B4CA4A2EBBD995003F7C53 /* KeychainService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainService.swift; sourceTree = "<group>"; };
 		F4CB866B2EE49D1D0066AEDA /* SSH TunnelBuilderTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "SSH TunnelBuilderTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		F47CCD382FDB4F1500BBECDF /* Exceptions for "SSH TunnelBuilder" folder in "SSH TunnelBuilderTests" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Classes/SSHTunnelError.swift,
+			);
+			target = F4CB866A2EE49D1D0066AEDA /* SSH TunnelBuilderTests */;
+		};
 		F49710F62EF01016003ADB19 /* Exceptions for "SSH TunnelBuilderTests" folder in "SSH TunnelBuilder" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
@@ -76,22 +58,21 @@
 			);
 			target = F4ABBF5327DFDF730097436A /* SSH TunnelBuilder */;
 		};
-		F49710F72EF01016003ADB19 /* Exceptions for "SSH TunnelBuilderTests" folder in "SSH TunnelBuilderTests" target */ = {
-			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
-			membershipExceptions = (
-				SSH_TunnelBuilderTests.swift,
-				SSHManagerTests.swift,
-			);
-			target = F4CB866A2EE49D1D0066AEDA /* SSH TunnelBuilderTests */;
-		};
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
+		F47CCD262FDB4F1400BBECDF /* SSH TunnelBuilder */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				F47CCD382FDB4F1500BBECDF /* Exceptions for "SSH TunnelBuilder" folder in "SSH TunnelBuilderTests" target */,
+			);
+			path = "SSH TunnelBuilder";
+			sourceTree = "<group>";
+		};
 		F4CB866C2EE49D1D0066AEDA /* SSH TunnelBuilderTests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
 				F49710F62EF01016003ADB19 /* Exceptions for "SSH TunnelBuilderTests" folder in "SSH TunnelBuilder" target */,
-				F49710F72EF01016003ADB19 /* Exceptions for "SSH TunnelBuilderTests" folder in "SSH TunnelBuilderTests" target */,
 			);
 			path = "SSH TunnelBuilderTests";
 			sourceTree = "<group>";
@@ -102,12 +83,21 @@
 		F4ABBF5127DFDF730097436A /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			files = (
-				F4A6A56A2EF2C73E000C2B1C /* NIOSSH in Frameworks */,
-				F45BB0992EE4274A000B4FA8 /* NIO in Frameworks */,
-				F45BB09F2EE4274A000B4FA8 /* NIOEmbedded in Frameworks */,
-				F45BB0A32EE4274A000B4FA8 /* NIOTLS in Frameworks */,
-				F45BB09D2EE4274A000B4FA8 /* NIOCore in Frameworks */,
-				F45BB09B2EE4274A000B4FA8 /* NIOConcurrencyHelpers in Frameworks */,
+				F47CCD482FDB592A00BBECDF /* NIOFoundationEssentialsCompat in Frameworks */,
+				F47CCD4C2FDB592A00BBECDF /* NIOPosix in Frameworks */,
+				F47CCD402FDB592A00BBECDF /* NIOConcurrencyHelpers in Frameworks */,
+				F47CCD502FDB592A00BBECDF /* NIOTestUtils in Frameworks */,
+				F47CCD3B2FDB588600BBECDF /* NIOSSH in Frameworks */,
+				F47CCD522FDB592A00BBECDF /* NIOWebSocket in Frameworks */,
+				F47CCD562FDB592A00BBECDF /* _NIOFileSystem in Frameworks */,
+				F47CCD422FDB592A00BBECDF /* NIOCore in Frameworks */,
+				F47CCD4E2FDB592A00BBECDF /* NIOTLS in Frameworks */,
+				F47CCD582FDB592A00BBECDF /* _NIOFileSystemFoundationCompat in Frameworks */,
+				F47CCD3E2FDB592A00BBECDF /* NIO in Frameworks */,
+				F47CCD462FDB592A00BBECDF /* NIOFoundationCompat in Frameworks */,
+				F47CCD442FDB592A00BBECDF /* NIOEmbedded in Frameworks */,
+				F47CCD542FDB592A00BBECDF /* _NIOConcurrency in Frameworks */,
+				F47CCD4A2FDB592A00BBECDF /* NIOHTTP1 in Frameworks */,
 			);
 		};
 		F4CB86682EE49D1D0066AEDA /* Frameworks */ = {
@@ -126,37 +116,10 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		F4700F8629D7696F0069DC6D /* GUI */ = {
-			isa = PBXGroup;
-			children = (
-				F4ABBF5927DFDF730097436A /* ContentView.swift */,
-				F4700F8029D7669E0069DC6D /* NavigationView.swift */,
-				F4700F8229D7670D0069DC6D /* MainView.swift */,
-				F4700F8429D768E20069DC6D /* ConnectionRow.swift */,
-				F422C57929E46B2B007306BC /* DataCounterView.swift */,
-				F4AA684E2F3533540065E097 /* SampleData.swift */,
-			);
-			path = GUI;
-			sourceTree = "<group>";
-		};
-		F4700F8729D769A00069DC6D /* Classes */ = {
-			isa = PBXGroup;
-			children = (
-				F49EBCB129D367A500A43775 /* ConnectionStore.swift */,
-				F49EBCB329D367A900A43775 /* Connection.swift */,
-				F4B4CA452EBBCA31003F7C53 /* SSHManager.swift */,
-				F4B4CA4A2EBBD995003F7C53 /* KeychainService.swift */,
-				F4A368BF2EE9943A00762D9D /* PEMDecryptor.swift */,
-				F4AA68502F3533F80065E097 /* Logger.swift */,
-				F4AA685C2F35400A0065E097 /* SSHTunnelError.swift */,
-			);
-			path = Classes;
-			sourceTree = "<group>";
-		};
 		F4ABBF4B27DFDF730097436A = {
 			isa = PBXGroup;
 			children = (
-				F4ABBF5627DFDF730097436A /* SSH TunnelBuilder */,
+				F47CCD262FDB4F1400BBECDF /* SSH TunnelBuilder */,
 				F4CB866C2EE49D1D0066AEDA /* SSH TunnelBuilderTests */,
 				F4ABBF5527DFDF730097436A /* Products */,
 				F4B4CA422EBBC20E003F7C53 /* README.md */,
@@ -175,27 +138,6 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		F4ABBF5627DFDF730097436A /* SSH TunnelBuilder */ = {
-			isa = PBXGroup;
-			children = (
-				F4700F8729D769A00069DC6D /* Classes */,
-				F4700F8629D7696F0069DC6D /* GUI */,
-				F4ABBF5727DFDF730097436A /* SSH_TunnelBuilderApp.swift */,
-				F4ABBF5B27DFDF740097436A /* Assets.xcassets */,
-				F4ABBF6527DFDF740097436A /* SSH_TunnelBuilder.entitlements */,
-				F4ABBF5D27DFDF740097436A /* Preview Content */,
-			);
-			path = "SSH TunnelBuilder";
-			sourceTree = "<group>";
-		};
-		F4ABBF5D27DFDF740097436A /* Preview Content */ = {
-			isa = PBXGroup;
-			children = (
-				F4ABBF5E27DFDF740097436A /* Preview Assets.xcassets */,
-			);
-			path = "Preview Content";
-			sourceTree = "<group>";
-		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -209,7 +151,27 @@
 			);
 			buildRules = (
 			);
+			fileSystemSynchronizedGroups = (
+				F47CCD262FDB4F1400BBECDF /* SSH TunnelBuilder */,
+			);
 			name = "SSH TunnelBuilder";
+			packageProductDependencies = (
+				F47CCD3A2FDB588600BBECDF /* NIOSSH */,
+				F47CCD3D2FDB592A00BBECDF /* NIO */,
+				F47CCD3F2FDB592A00BBECDF /* NIOConcurrencyHelpers */,
+				F47CCD412FDB592A00BBECDF /* NIOCore */,
+				F47CCD432FDB592A00BBECDF /* NIOEmbedded */,
+				F47CCD452FDB592A00BBECDF /* NIOFoundationCompat */,
+				F47CCD472FDB592A00BBECDF /* NIOFoundationEssentialsCompat */,
+				F47CCD492FDB592A00BBECDF /* NIOHTTP1 */,
+				F47CCD4B2FDB592A00BBECDF /* NIOPosix */,
+				F47CCD4D2FDB592A00BBECDF /* NIOTLS */,
+				F47CCD4F2FDB592A00BBECDF /* NIOTestUtils */,
+				F47CCD512FDB592A00BBECDF /* NIOWebSocket */,
+				F47CCD532FDB592A00BBECDF /* _NIOConcurrency */,
+				F47CCD552FDB592A00BBECDF /* _NIOFileSystem */,
+				F47CCD572FDB592A00BBECDF /* _NIOFileSystemFoundationCompat */,
+			);
 			productName = "SSH TunnelBuilder2";
 			productReference = F4ABBF5427DFDF730097436A /* SSH TunnelBuilder.app */;
 			productType = "com.apple.product-type.application";
@@ -264,8 +226,8 @@
 			);
 			mainGroup = F4ABBF4B27DFDF730097436A;
 			packageReferences = (
-				F45BB0972EE4274A000B4FA8 /* XCRemoteSwiftPackageReference "swift-nio" */,
-				F4A6A5682EF2C73E000C2B1C /* XCRemoteSwiftPackageReference "swift-nio-ssh" */,
+				F47CCD392FDB588600BBECDF /* XCRemoteSwiftPackageReference "swift-nio-ssh" */,
+				F47CCD3C2FDB592A00BBECDF /* XCRemoteSwiftPackageReference "swift-nio" */,
 			);
 			preferredProjectObjectVersion = 90;
 			productRefGroup = F4ABBF5527DFDF730097436A /* Products */;
@@ -282,8 +244,6 @@
 		F4ABBF5227DFDF730097436A /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			files = (
-				F4ABBF5F27DFDF740097436A /* Preview Assets.xcassets in Resources */,
-				F4ABBF5C27DFDF740097436A /* Assets.xcassets in Resources */,
 			);
 		};
 		F4CB86692EE49D1D0066AEDA /* Resources */ = {
@@ -297,26 +257,11 @@
 		F4ABBF5027DFDF730097436A /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			files = (
-				F4AA685E2F35400A0065E097 /* SSHTunnelError.swift in Sources */,
-				F4A368C02EE9964400762D9D /* PEMDecryptor.swift in Sources */,
-				F49EBCB429D367A900A43775 /* Connection.swift in Sources */,
-				F4700F8529D768E20069DC6D /* ConnectionRow.swift in Sources */,
-				F4700F8329D7670D0069DC6D /* MainView.swift in Sources */,
-				F4B4CA4B2EBBD995003F7C53 /* KeychainService.swift in Sources */,
-				F4ABBF5A27DFDF730097436A /* ContentView.swift in Sources */,
-				F4AA684F2F3533540065E097 /* SampleData.swift in Sources */,
-				F4700F8129D7669E0069DC6D /* NavigationView.swift in Sources */,
-				F4B4CA462EBBCA31003F7C53 /* SSHManager.swift in Sources */,
-				F422C57A29E46B2B007306BC /* DataCounterView.swift in Sources */,
-				F49EBCB229D367A500A43775 /* ConnectionStore.swift in Sources */,
-				F4ABBF5827DFDF730097436A /* SSH_TunnelBuilderApp.swift in Sources */,
-				F4AA68512F3533F80065E097 /* Logger.swift in Sources */,
 			);
 		};
 		F4CB86672EE49D1D0066AEDA /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			files = (
-				F4AA68602F35400A0065E097 /* SSHTunnelError.swift in Sources */,
 			);
 		};
 /* End PBXSourcesBuildPhase section */
@@ -491,7 +436,7 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.6;
 				MARKETING_VERSION = 2.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "no.comraich.SSH-TunnelBuilder";
+				PRODUCT_BUNDLE_IDENTIFIER = no.comraich.sshTunnelBuilder;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -535,7 +480,7 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.6;
 				MARKETING_VERSION = 2.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "no.comraich.SSH-TunnelBuilder";
+				PRODUCT_BUNDLE_IDENTIFIER = no.comraich.sshTunnelBuilder;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -622,54 +567,99 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		F45BB0972EE4274A000B4FA8 /* XCRemoteSwiftPackageReference "swift-nio" */ = {
+		F47CCD392FDB588600BBECDF /* XCRemoteSwiftPackageReference "swift-nio-ssh" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/apple/swift-nio-ssh.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.13.0;
+			};
+		};
+		F47CCD3C2FDB592A00BBECDF /* XCRemoteSwiftPackageReference "swift-nio" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/apple/swift-nio.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 2.91.0;
-			};
-		};
-		F4A6A5682EF2C73E000C2B1C /* XCRemoteSwiftPackageReference "swift-nio-ssh" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/Comraich/swift-nio-ssh.git";
-			requirement = {
-				branch = main;
-				kind = branch;
+				minimumVersion = 2.101.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		F45BB0982EE4274A000B4FA8 /* NIO */ = {
+		F47CCD3A2FDB588600BBECDF /* NIOSSH */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = F45BB0972EE4274A000B4FA8 /* XCRemoteSwiftPackageReference "swift-nio" */;
+			package = F47CCD392FDB588600BBECDF /* XCRemoteSwiftPackageReference "swift-nio-ssh" */;
+			productName = NIOSSH;
+		};
+		F47CCD3D2FDB592A00BBECDF /* NIO */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F47CCD3C2FDB592A00BBECDF /* XCRemoteSwiftPackageReference "swift-nio" */;
 			productName = NIO;
 		};
-		F45BB09A2EE4274A000B4FA8 /* NIOConcurrencyHelpers */ = {
+		F47CCD3F2FDB592A00BBECDF /* NIOConcurrencyHelpers */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = F45BB0972EE4274A000B4FA8 /* XCRemoteSwiftPackageReference "swift-nio" */;
+			package = F47CCD3C2FDB592A00BBECDF /* XCRemoteSwiftPackageReference "swift-nio" */;
 			productName = NIOConcurrencyHelpers;
 		};
-		F45BB09C2EE4274A000B4FA8 /* NIOCore */ = {
+		F47CCD412FDB592A00BBECDF /* NIOCore */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = F45BB0972EE4274A000B4FA8 /* XCRemoteSwiftPackageReference "swift-nio" */;
+			package = F47CCD3C2FDB592A00BBECDF /* XCRemoteSwiftPackageReference "swift-nio" */;
 			productName = NIOCore;
 		};
-		F45BB09E2EE4274A000B4FA8 /* NIOEmbedded */ = {
+		F47CCD432FDB592A00BBECDF /* NIOEmbedded */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = F45BB0972EE4274A000B4FA8 /* XCRemoteSwiftPackageReference "swift-nio" */;
+			package = F47CCD3C2FDB592A00BBECDF /* XCRemoteSwiftPackageReference "swift-nio" */;
 			productName = NIOEmbedded;
 		};
-		F45BB0A22EE4274A000B4FA8 /* NIOTLS */ = {
+		F47CCD452FDB592A00BBECDF /* NIOFoundationCompat */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = F45BB0972EE4274A000B4FA8 /* XCRemoteSwiftPackageReference "swift-nio" */;
+			package = F47CCD3C2FDB592A00BBECDF /* XCRemoteSwiftPackageReference "swift-nio" */;
+			productName = NIOFoundationCompat;
+		};
+		F47CCD472FDB592A00BBECDF /* NIOFoundationEssentialsCompat */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F47CCD3C2FDB592A00BBECDF /* XCRemoteSwiftPackageReference "swift-nio" */;
+			productName = NIOFoundationEssentialsCompat;
+		};
+		F47CCD492FDB592A00BBECDF /* NIOHTTP1 */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F47CCD3C2FDB592A00BBECDF /* XCRemoteSwiftPackageReference "swift-nio" */;
+			productName = NIOHTTP1;
+		};
+		F47CCD4B2FDB592A00BBECDF /* NIOPosix */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F47CCD3C2FDB592A00BBECDF /* XCRemoteSwiftPackageReference "swift-nio" */;
+			productName = NIOPosix;
+		};
+		F47CCD4D2FDB592A00BBECDF /* NIOTLS */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F47CCD3C2FDB592A00BBECDF /* XCRemoteSwiftPackageReference "swift-nio" */;
 			productName = NIOTLS;
 		};
-		F4A6A5692EF2C73E000C2B1C /* NIOSSH */ = {
+		F47CCD4F2FDB592A00BBECDF /* NIOTestUtils */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = F4A6A5682EF2C73E000C2B1C /* XCRemoteSwiftPackageReference "swift-nio-ssh" */;
-			productName = NIOSSH;
+			package = F47CCD3C2FDB592A00BBECDF /* XCRemoteSwiftPackageReference "swift-nio" */;
+			productName = NIOTestUtils;
+		};
+		F47CCD512FDB592A00BBECDF /* NIOWebSocket */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F47CCD3C2FDB592A00BBECDF /* XCRemoteSwiftPackageReference "swift-nio" */;
+			productName = NIOWebSocket;
+		};
+		F47CCD532FDB592A00BBECDF /* _NIOConcurrency */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F47CCD3C2FDB592A00BBECDF /* XCRemoteSwiftPackageReference "swift-nio" */;
+			productName = _NIOConcurrency;
+		};
+		F47CCD552FDB592A00BBECDF /* _NIOFileSystem */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F47CCD3C2FDB592A00BBECDF /* XCRemoteSwiftPackageReference "swift-nio" */;
+			productName = _NIOFileSystem;
+		};
+		F47CCD572FDB592A00BBECDF /* _NIOFileSystemFoundationCompat */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F47CCD3C2FDB592A00BBECDF /* XCRemoteSwiftPackageReference "swift-nio" */;
+			productName = _NIOFileSystemFoundationCompat;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/SSH TunnelBuilder/Classes/SSHManager.swift
+++ b/SSH TunnelBuilder/Classes/SSHManager.swift
@@ -158,7 +158,7 @@ internal enum OpenSSHKeyParser {
     static func readSSHBytes(from buffer: inout ByteBuffer) throws -> [UInt8] { return try FlexibleAuthDelegate.readSSHBytes(from: &buffer) }
 }
 
-private final class FlexibleAuthDelegate: NIOSSHClientUserAuthenticationDelegate, Sendable {
+final class FlexibleAuthDelegate: NIOSSHClientUserAuthenticationDelegate, Sendable {
     let username: String
     let password: String?
     let privateKey: NIOSSHPrivateKey?

--- a/SSH TunnelBuilder/Classes/SSHManager.swift
+++ b/SSH TunnelBuilder/Classes/SSHManager.swift
@@ -1,6 +1,6 @@
 import Foundation
 import NIO
-import NIOSSH
+@preconcurrency import NIOSSH
 import CryptoKit
 import Combine
 
@@ -345,11 +345,15 @@ private extension FlexibleAuthDelegate {
         if keyType == "ssh-ed25519" {
             // Pub key
             let _ = try readSSHBytes(from: &privateBuffer)
-            // Priv key
+            // Priv key — OpenSSH stores 64 bytes: seed (32) || public key (32).
+            // Curve25519.Signing.PrivateKey takes the 32-byte seed as rawRepresentation.
             let keyBytes = try readSSHBytes(from: &privateBuffer)
-            
-            // NIOSSH expects the OpenSSH Ed25519 blob
-            return try NIOSSHPrivateKey(openSSHEd25519PrivateKeyBlob: keyBytes)
+            guard keyBytes.count >= 32 else {
+                throw OpenSSHKeyParser.OpenSSHParsingError.invalidKeyFormat(reason: "Ed25519 private key blob too short (\(keyBytes.count) bytes)")
+            }
+            let seed = Data(keyBytes.prefix(32))
+            let ed25519Key = try Curve25519.Signing.PrivateKey(rawRepresentation: seed)
+            return NIOSSHPrivateKey(ed25519Key: ed25519Key)
         } else if keyType.hasPrefix("ecdsa-sha2-") {
             let curveName = try readSSHString(from: &privateBuffer)
             let _ = try readSSHBytes(from: &privateBuffer) // Public Key

--- a/SSH TunnelBuilder/SSH_TunnelBuilder2.xcdatamodeld/.xccurrentversion
+++ b/SSH TunnelBuilder/SSH_TunnelBuilder2.xcdatamodeld/.xccurrentversion
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict/>
-</plist>

--- a/SSH TunnelBuilder/SSH_TunnelBuilder2.xcdatamodeld/SSH_TunnelBuilder2.xcdatamodel/contents
+++ b/SSH TunnelBuilder/SSH_TunnelBuilder2.xcdatamodeld/SSH_TunnelBuilder2.xcdatamodel/contents
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="1" systemVersion="11A491" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithCloudKit="true" userDefinedModelVersionIdentifier="">
-    <entity name="Item" representedClassName="Item" syncable="YES" codeGenerationType="class">
-        <attribute name="timestamp" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
-    </entity>
-    <elements>
-        <element name="Item" positionX="-63" positionY="-18" width="128" height="44"/>
-    </elements>
-</model>

--- a/SSH TunnelBuilderTests/SSH_TunnelBuilderTests.swift
+++ b/SSH TunnelBuilderTests/SSH_TunnelBuilderTests.swift
@@ -1,205 +1,303 @@
 import Testing
 import Foundation
 import NIO
-import NIOSSH // Required for NIOSSHAvailableUserAuthenticationMethods
+import NIOSSH
 import CloudKit
 import CryptoKit
 
-// This import gives the test target access to your app's internal types like KeychainService.
 @testable import SSH_TunnelBuilder
 
-// NOTE: Since KeychainService is a singleton, these tests will interact
-// with the app's actual keychain during the test run. We use a unique
-// ID for each test to ensure we don't conflict with real data or other tests.
+// MARK: - Keychain Service Tests
 
 @Suite("Keychain Service Tests")
 struct KeychainServiceTests {
     let keychain = KeychainService.shared
-    
+
     @Test("Save, load, and delete password")
     func testPasswordLifecycle() {
         let id = UUID()
-        let password = "super-secret-password-123"
-        
-        // 1. Save the password
-        keychain.savePassword(password, for: id)
-        
-        // 2. Load and verify the password
-        let loadedPassword = keychain.loadPassword(for: id)
-        #expect(loadedPassword == password, "The loaded password should match the saved password.")
-        
-        // 3. Delete the credentials
+        keychain.savePassword("super-secret-password-123", for: id)
+        #expect(keychain.loadPassword(for: id) == "super-secret-password-123")
         keychain.deleteCredentials(for: id)
-        
-        // 4. Verify the password is deleted
-        let deletedPassword = keychain.loadPassword(for: id)
-        #expect(deletedPassword == nil, "The password should be nil after deletion.")
+        #expect(keychain.loadPassword(for: id) == nil)
     }
-    
+
     @Test("Save, load, and delete private key")
     func testPrivateKeyLifecycle() {
         let id = UUID()
-        let privateKey = "-----BEGIN EC PRIVATE KEY-----\nTestKeyData\n-----END EC PRIVATE KEY-----"
-        
-        // 1. Save the key
-        keychain.savePrivateKey(privateKey, for: id)
-        
-        // 2. Load and verify the key
-        let loadedKey = keychain.loadPrivateKey(for: id)
-        #expect(loadedKey == privateKey, "The loaded private key should match the saved key.")
-        
-        // 3. Delete the credentials
+        let key = "-----BEGIN EC PRIVATE KEY-----\nTestKeyData\n-----END EC PRIVATE KEY-----"
+        keychain.savePrivateKey(key, for: id)
+        #expect(keychain.loadPrivateKey(for: id) == key)
         keychain.deleteCredentials(for: id)
-        
-        // 4. Verify the key is deleted
-        let deletedKey = keychain.loadPrivateKey(for: id)
-        #expect(deletedKey == nil, "The private key should be nil after deletion.")
+        #expect(keychain.loadPrivateKey(for: id) == nil)
     }
-    
+
     @Test("Loading non-existent credential returns nil")
     func testLoadingNonExistent() {
-        let id = UUID() // A random ID that has not been saved
-        
-        let password = keychain.loadPassword(for: id)
-        #expect(password == nil, "Loading a password for an unknown ID should return nil.")
-        
-        let privateKey = keychain.loadPrivateKey(for: id)
-        #expect(privateKey == nil, "Loading a private key for an unknown ID should return nil.")
+        let id = UUID()
+        #expect(keychain.loadPassword(for: id) == nil)
+        #expect(keychain.loadPrivateKey(for: id) == nil)
     }
-    
+
     @Test("Updating a credential overwrites the old one")
     func testUpdateCredential() {
         let id = UUID()
-        let initialPassword = "password1"
-        let updatedPassword = "password2"
-        
-        // 1. Save initial password
-        keychain.savePassword(initialPassword, for: id)
-        let firstLoad = keychain.loadPassword(for: id)
-        #expect(firstLoad == initialPassword)
-        
-        // 2. Save updated password
-        keychain.savePassword(updatedPassword, for: id)
-        let secondLoad = keychain.loadPassword(for: id)
-        #expect(secondLoad == updatedPassword, "The updated password should overwrite the initial one.")
-        
-        // Clean up
+        keychain.savePassword("password1", for: id)
+        #expect(keychain.loadPassword(for: id) == "password1")
+        keychain.savePassword("password2", for: id)
+        #expect(keychain.loadPassword(for: id) == "password2")
         keychain.deleteCredentials(for: id)
     }
 }
 
-// MARK: - New ConnectionStore Local Tests
+// MARK: - ConnectionState Tests
 
-@Suite("ConnectionStore Local Tests")
-@MainActor
-struct ConnectionStoreLocalTests {
-    
-    // Helper to mock the connection object needed for testing
-    func makeMockConnection(id: UUID = UUID(), password: String, privateKey: String) -> Connection {
-        let info = ConnectionInfo(name: "Mock", serverAddress: "127.0.0.1", portNumber: "22", username: "user", password: password, privateKey: privateKey, privateKeyPassphrase: "")
-        let tunnel = TunnelInfo(localPort: "8080", remoteServer: "remote", remotePort: "80")
-        return Connection(id: id, connectionInfo: info, tunnelInfo: tunnel)
-    }
-    
-    // Use an instance of ConnectionStore to access helper methods like recordToConnection
-    // NOTE: This test suite avoids triggering the actual CloudKit initiation (`init()`) 
-    // but relies on helper methods being available.
-    
-    @Test("Secrets are saved to Keychain and retrieved correctly via recordToConnection")
-    func testSecretHandlingInRecordMapping() throws {
-        let store = ConnectionStore()
-        let id = UUID()
-        let initialPassword = "test_password"
-        let initialKey = "test_key_pem"
-        let mockConnection = makeMockConnection(id: id, password: initialPassword, privateKey: initialKey)
-        
-        let zoneID = CKRecordZone.ID(zoneName: "TestZone", ownerName: CKCurrentUserDefaultName)
-        let recordID = CKRecord.ID(recordName: id.uuidString, zoneID: zoneID)
-        let record = CKRecord(recordType: "Connection", recordID: recordID)
-        
-        // 1. Simulate saving the connection (which calls updateRecordFields)
-        store.updateRecordFields(record, withConnection: mockConnection)
-        
-        // Verify secrets are cleared from the record (CK security principle)
-        let recordPassword = record[CloudKitKeys.password] as? String
-        let recordKey = record[CloudKitKeys.privateKey] as? String
-        #expect(recordPassword == "" || recordPassword == nil)
-        #expect(recordKey == "" || recordKey == nil)
-        
-        // 2. Simulate retrieving the connection (which calls recordToConnection)
-        let retrievedConnection = try #require(store.recordToConnection(record: record))
-        
-        // Verify secrets are correctly retrieved from Keychain
-        #expect(retrievedConnection.connectionInfo.password == initialPassword)
-        #expect(retrievedConnection.connectionInfo.privateKey == initialKey)
-        
-        // Cleanup
-        KeychainService.shared.deleteCredentials(for: id)
-    }
-    
-    @Test("Updating temporary connection uses deep copy")
-    func testTempConnectionUpdate() {
-        let store = ConnectionStore()
-        let originalConnection = makeMockConnection(password: "p1", privateKey: "k1")
-        
-        store.updateTempConnection(with: originalConnection)
-        let tempConnection = try #require(store.tempConnection)
-        
-        // Modify the copy
-        tempConnection.connectionInfo.password = "p2"
-        
-        // Verify original is untouched
-        #expect(originalConnection.connectionInfo.password == "p1")
+@Suite("ConnectionState Tests")
+struct ConnectionStateTests {
+    @Test("isActive is true only when connected")
+    func isActiveOnlyWhenConnected() {
+        #expect(!ConnectionState.idle.isActive)
+        #expect(!ConnectionState.connecting.isActive)
+        #expect(ConnectionState.connected.isActive)
+        #expect(!ConnectionState.disconnecting.isActive)
+        #expect(!ConnectionState.failed("err").isActive)
     }
 
-    @Test("Connection deletion cleans up manager and keychain") {
-        let store = ConnectionStore()
-        let id = UUID()
-        let connection = makeMockConnection(id: id, password: "test", privateKey: "test")
-        
-        // Setup: Ensure manager and keychain data exist
-        KeychainService.shared.savePassword("test", for: id)
-        
-        // Mock a minimal CKRecord ID to allow the delete logic to execute locally
-        let recordID = CKRecord.ID(recordName: id.uuidString)
-        let connectionToDelete = Connection(id: id, recordID: recordID, connectionInfo: connection.connectionInfo, tunnelInfo: connection.tunnelInfo)
-        
-        store.connections.append(connectionToDelete)
-        
-        // Mock the CloudKit delete operation (We assume success here for local cleanup test)
-        // Since deleteConnection is async, we can't fully test manager cleanup without a CloudKit mock, 
-        // but we can simulate the successful post-CloudKit cleanup logic.
-        
-        // Manually simulating successful CK deletion to trigger local cleanup logic
-        Task {
-            // Note: Since ConnectionStore.deleteConnection calls disconnect, 
-            // and we rely on the CloudKit DELETE succeeding, full end-to-end testing of deletion 
-            // requires mocking CKDatabase responses.
-            
-            // However, we can assert that Keychain cleanup should happen:
-            // Since we cannot easily await the full async flow without complex mocks,
-            // we rely on the fact that the keychain data should be deleted eventually 
-            // after the deleteConnection call. For now, we manually check the code path's intent.
-            // (If using a mocking framework, we would assert database.delete was called, 
-            // and then assert the keychain deletion.)
-            
-            // For now, focus on the synchronous cleanup inside recordToConnection and updateRecordFields.
-            
-            // Re-adding this test for future development where proper mocking might be available.
-            
-            // The fact that mgr is retained in `managers` dictionary is the main local concern.
-            
-            // Cleanup assertion verification is best left to integration/mocking for async deletion.
-        }
-        
-        // Resetting the list of connections is synchronous after the async delete is complete
+    @Test("isConnecting is true only when connecting")
+    func isConnectingOnlyWhenConnecting() {
+        #expect(!ConnectionState.idle.isConnecting)
+        #expect(ConnectionState.connecting.isConnecting)
+        #expect(!ConnectionState.connected.isConnecting)
+        #expect(!ConnectionState.disconnecting.isConnecting)
+        #expect(!ConnectionState.failed("err").isConnecting)
+    }
+
+    @Test("isDisconnecting is true only when disconnecting")
+    func isDisconnectingOnlyWhenDisconnecting() {
+        #expect(!ConnectionState.idle.isDisconnecting)
+        #expect(!ConnectionState.connecting.isDisconnecting)
+        #expect(!ConnectionState.connected.isDisconnecting)
+        #expect(ConnectionState.disconnecting.isDisconnecting)
+        #expect(!ConnectionState.failed("err").isDisconnecting)
+    }
+
+    @Test("isFailed is true only when failed")
+    func isFailedOnlyWhenFailed() {
+        #expect(!ConnectionState.idle.isFailed)
+        #expect(!ConnectionState.connecting.isFailed)
+        #expect(!ConnectionState.connected.isFailed)
+        #expect(!ConnectionState.disconnecting.isFailed)
+        #expect(ConnectionState.failed("err").isFailed)
+    }
+
+    @Test("errorMessage carries the failure reason")
+    func errorMessageCarriesReason() {
+        let reason = "Connection refused"
+        #expect(ConnectionState.failed(reason).errorMessage == reason)
+        #expect(ConnectionState.idle.errorMessage == nil)
+        #expect(ConnectionState.connected.errorMessage == nil)
+    }
+
+    @Test("States with equal associated values compare equal")
+    func equalityWithAssociatedValues() {
+        #expect(ConnectionState.failed("a") == ConnectionState.failed("a"))
+        #expect(ConnectionState.failed("a") != ConnectionState.failed("b"))
+        #expect(ConnectionState.idle == ConnectionState.idle)
+        #expect(ConnectionState.idle != ConnectionState.connected)
     }
 }
 
+// MARK: - Port Field Bridging Tests
+
+/// Tests the String <-> Int64 bridge for the port fields whose CloudKit schema
+/// type is NUMBER_INT64. This is the fix for the core persistence bug (CKError 12).
+@Suite("Port Field Bridging Tests")
+struct PortFieldBridgingTests {
+    @MainActor func makeStore() -> ConnectionStore {
+        ConnectionStore(mode: .view, connections: [])
+    }
+
+    @MainActor func makeConnection(id: UUID = UUID(), portNumber: String, localPort: String, remotePort: String) -> Connection {
+        let info = ConnectionInfo(name: "Port Test", serverAddress: "host.example.com",
+                                  portNumber: portNumber, username: "user",
+                                  password: "", privateKey: "", privateKeyPassphrase: "")
+        let tunnel = TunnelInfo(localPort: localPort, remoteServer: "remote", remotePort: remotePort)
+        return Connection(id: id, connectionInfo: info, tunnelInfo: tunnel)
+    }
+
+    @Test("Numeric port strings are written as Int64 and read back as String")
+    @MainActor func numericPortsRoundTrip() throws {
+        let store = makeStore()
+        let id = UUID()
+        let connection = makeConnection(id: id, portNumber: "22", localPort: "8080", remotePort: "5432")
+
+        let record = CKRecord(recordType: "Connection",
+                              recordID: CKRecord.ID(recordName: id.uuidString))
+        store.updateRecordFields(record, withConnection: connection)
+
+        // Verify stored as Int64 (matching the CloudKit schema)
+        #expect(record["portNumber"] as? Int64 == 22)
+        #expect(record["localPort"] as? Int64 == 8080)
+        #expect(record["remotePort"] as? Int64 == 5432)
+
+        // Complete the record so recordToConnection can parse it
+        record["uuid"] = id.uuidString
+        record["name"] = "Port Test"
+        record["serverAddress"] = "host.example.com"
+        record["username"] = "user"
+        record["remoteServer"] = "remote"
+
+        let result = try #require(store.recordToConnection(record: record))
+        #expect(result.connectionInfo.portNumber == "22")
+        #expect(result.tunnelInfo.localPort == "8080")
+        #expect(result.tunnelInfo.remotePort == "5432")
+
+        KeychainService.shared.deleteCredentials(for: id)
+    }
+
+    @Test("Blank port strings are stored as absent fields and read back as empty string")
+    @MainActor func blankPortsAreAbsent() throws {
+        let store = makeStore()
+        let id = UUID()
+        let connection = makeConnection(id: id, portNumber: "", localPort: "", remotePort: "")
+
+        let record = CKRecord(recordType: "Connection",
+                              recordID: CKRecord.ID(recordName: id.uuidString))
+        store.updateRecordFields(record, withConnection: connection)
+
+        // Blank values should produce absent (nil) fields, not a zero
+        #expect(record["portNumber"] == nil)
+        #expect(record["localPort"] == nil)
+        #expect(record["remotePort"] == nil)
+
+        record["uuid"] = id.uuidString
+        record["name"] = "Port Test"
+        record["serverAddress"] = "host.example.com"
+        record["username"] = "user"
+        record["remoteServer"] = "remote"
+
+        let result = try #require(store.recordToConnection(record: record))
+        #expect(result.connectionInfo.portNumber == "")
+        #expect(result.tunnelInfo.localPort == "")
+        #expect(result.tunnelInfo.remotePort == "")
+
+        KeychainService.shared.deleteCredentials(for: id)
+    }
+
+    @Test("Non-numeric port strings are stored as absent fields")
+    @MainActor func nonNumericPortsAreAbsent() {
+        let store = makeStore()
+        let id = UUID()
+        let connection = makeConnection(id: id, portNumber: "not-a-port", localPort: "abc", remotePort: "xyz")
+
+        let record = CKRecord(recordType: "Connection",
+                              recordID: CKRecord.ID(recordName: id.uuidString))
+        store.updateRecordFields(record, withConnection: connection)
+
+        #expect(record["portNumber"] == nil)
+        #expect(record["localPort"] == nil)
+        #expect(record["remotePort"] == nil)
+    }
+
+    @Test("Legacy Int64 values in a CKRecord are read back as String")
+    @MainActor func legacyInt64FieldsReadAsString() throws {
+        // Simulate a record returned from the server with Int64 port fields
+        let store = makeStore()
+        let id = UUID()
+
+        let record = CKRecord(recordType: "Connection",
+                              recordID: CKRecord.ID(recordName: id.uuidString))
+        record["uuid"] = id.uuidString
+        record["name"] = "DB Server"
+        record["serverAddress"] = "db.example.com"
+        record["username"] = "admin"
+        record["remoteServer"] = "localhost"
+        record["portNumber"] = Int64(2222)
+        record["localPort"]   = Int64(5433)
+        record["remotePort"]  = Int64(5432)
+
+        let result = try #require(store.recordToConnection(record: record))
+        #expect(result.connectionInfo.portNumber == "2222")
+        #expect(result.tunnelInfo.localPort == "5433")
+        #expect(result.tunnelInfo.remotePort == "5432")
+
+        KeychainService.shared.deleteCredentials(for: id)
+    }
+}
+
+// MARK: - ConnectionStore Local Tests
+
+@Suite("ConnectionStore Local Tests")
+struct ConnectionStoreLocalTests {
+    @MainActor func makeMockConnection(id: UUID = UUID(), password: String, privateKey: String) -> Connection {
+        let info = ConnectionInfo(name: "Mock", serverAddress: "127.0.0.1",
+                                  portNumber: "22", username: "user",
+                                  password: password, privateKey: privateKey,
+                                  privateKeyPassphrase: "")
+        let tunnel = TunnelInfo(localPort: "8080", remoteServer: "remote", remotePort: "80")
+        return Connection(id: id, connectionInfo: info, tunnelInfo: tunnel)
+    }
+
+    @Test("Secrets are saved to Keychain and retrieved correctly via recordToConnection")
+    @MainActor func testSecretHandlingInRecordMapping() throws {
+        let store = ConnectionStore(mode: .view, connections: [])
+        let id = UUID()
+        let mockConnection = makeMockConnection(id: id, password: "test_password", privateKey: "test_key_pem")
+
+        let zoneID = CKRecordZone.ID(zoneName: "TestZone", ownerName: CKCurrentUserDefaultName)
+        let recordID = CKRecord.ID(recordName: id.uuidString, zoneID: zoneID)
+        let record = CKRecord(recordType: "Connection", recordID: recordID)
+
+        store.updateRecordFields(record, withConnection: mockConnection)
+        record["uuid"] = id.uuidString  // updateRecordFields doesn't set uuid; production code sets it separately
+
+        // Secrets must not be stored in CloudKit
+        #expect((record["password"] as? String ?? "") == "")
+        #expect((record["privateKey"] as? String ?? "") == "")
+
+        // Secrets must be recoverable via the store's credentials layer
+        let retrieved = try #require(store.recordToConnection(record: record))
+        #expect(retrieved.connectionInfo.password == "test_password")
+        #expect(retrieved.connectionInfo.privateKey == "test_key_pem")
+    }
+
+    @Test("Updating temporary connection uses a deep copy")
+    @MainActor func testTempConnectionUpdate() throws {
+        let store = ConnectionStore(mode: .view, connections: [])
+        let original = makeMockConnection(password: "p1", privateKey: "k1")
+
+        store.updateTempConnection(with: original)
+        let temp = try #require(store.tempConnection)
+
+        temp.connectionInfo.password = "p2"
+        #expect(original.connectionInfo.password == "p1",
+                "Modifying the temp copy must not affect the original")
+    }
+
+    @Test("Deleting a local-only connection removes it synchronously from the list")
+    @MainActor func testLocalConnectionDeletion() {
+        let id = UUID()
+        let info = ConnectionInfo(name: "To Delete", serverAddress: "host",
+                                  portNumber: "22", username: "user",
+                                  password: "", privateKey: "", privateKeyPassphrase: "")
+        let tunnel = TunnelInfo(localPort: "8080", remoteServer: "remote", remotePort: "80")
+        // recordID: nil means this connection has never been synced to CloudKit
+        let connection = Connection(id: id, recordID: nil,
+                                    connectionInfo: info, tunnelInfo: tunnel)
+
+        let store = ConnectionStore(mode: .view, connections: [connection])
+        #expect(store.connections.count == 1)
+
+        store.deleteConnection(connection)
+        #expect(store.connections.isEmpty,
+                "A local-only connection should be removed synchronously from the list")
+    }
+}
+
+// MARK: - Authentication Delegate Tests
 
 @Suite("Authentication Delegate Tests")
 struct AuthDelegateTests {
-    // This is a known-valid, unencrypted EC PRIVATE KEY for P-256 (from original snippets)
     let p256TestKey = """
     -----BEGIN EC PRIVATE KEY-----
     MHcCAQEEIP2/85aP5w3A0a42M4pvi5b+4V2Fb6U2aT7g46Gl2nk9oAoGCCqGSM49
@@ -208,74 +306,91 @@ struct AuthDelegateTests {
     -----END EC PRIVATE KEY-----
     """
 
-    @Test("Delegate initializes with a valid unencrypted ECDSA key")
+    @Test("Delegate initializes with a valid unencrypted ECDSA P-256 key")
     func testValidUnencryptedECKeyInitialization() {
-        let delegate = FlexibleAuthDelegate(username: "test", password: nil, privateKeyString: p256TestKey, privateKeyPassphrase: nil)
-        #expect(delegate.privateKey != nil, "Delegate should successfully parse a valid unencrypted ECDSA P-256 key.")
+        let delegate = FlexibleAuthDelegate(username: "test", password: nil,
+                                            privateKeyString: p256TestKey,
+                                            privateKeyPassphrase: nil)
+        #expect(delegate.privateKey != nil)
     }
-    
-    @Test("Delegate rejects unsupported key type (RSA)") {
-        // RSA key in PKCS#1 format (which is detected and rejected by FlexibleAuthDelegate)
+
+    @Test("Delegate rejects an RSA key and records an initialization error")
+    func testRSAKeyRejected() {
         let rsaKey = """
         -----BEGIN RSA PRIVATE KEY-----
         MIICXQIBAAKBgQCw0/Vv1xR0z...
         -----END RSA PRIVATE KEY-----
         """
-        
-        var reportedError: String? = nil
-        let delegate = FlexibleAuthDelegate(username: "test", password: nil, privateKeyString: rsaKey, privateKeyPassphrase: nil, reportError: { reportedError = $0 })
-        
-        #expect(delegate.privateKey == nil, "Delegate should reject unsupported RSA key.")
-        #expect(reportedError?.contains("RSA keys are not currently supported") == true, "Delegate should report the RSA incompatibility error.")
+        // We check initializationError rather than using a reportError closure,
+        // which would require mutating a var from a @Sendable context.
+        let delegate = FlexibleAuthDelegate(username: "test", password: nil,
+                                            privateKeyString: rsaKey,
+                                            privateKeyPassphrase: nil)
+        #expect(delegate.privateKey == nil)
+        #expect(delegate.initializationError != nil)
     }
 
-    @Test("Delegate handles completely invalid key string")
+    @Test("Delegate returns nil private key for an unrecognisable key string")
     func testInvalidKeyInitialization() {
-        let delegate = FlexibleAuthDelegate(username: "test", password: nil, privateKeyString: "invalid-key-string", privateKeyPassphrase: nil)
-        #expect(delegate.privateKey == nil, "Delegate should return nil for an invalid key.")
-    }
-    
-    @Test("Delegate offers password when available and key auth is skipped")
-    func testOffersPasswordFallback() async throws {
-        // We ensure that even with a valid key, if password is also present, password takes precedence
-        // or is offered next if the key attempt fails/is skipped (as in 0.12.0).
-        let delegate = FlexibleAuthDelegate(username: "test", password: "pw", privateKeyString: p256TestKey)
-        
-        let eventLoop = EmbeddedEventLoop()
-        let promise = eventLoop.makePromise(of: NIOSSHUserAuthenticationOffer?.self)
-        
-        let availableMethods: NIOSSHAvailableUserAuthenticationMethods = [.publicKey, .password]
-        delegate.nextAuthenticationType(availableMethods: availableMethods, nextChallengePromise: promise)
-        
-        let offer = try await promise.futureResult.get()
-        
-        // Since public key authentication is skipped (due to the if block guard), it falls directly to password check.
-        #expect(offer?.offer.isPassword == true, "Should offer password if public key auth is skipped.")
+        let delegate = FlexibleAuthDelegate(username: "test", password: nil,
+                                            privateKeyString: "invalid-key-string",
+                                            privateKeyPassphrase: nil)
+        #expect(delegate.privateKey == nil)
     }
 
-    @Test("Delegate fails if neither key nor password available") async throws {
-        let delegate = FlexibleAuthDelegate(username: "test", password: nil, privateKeyString: nil)
-        
-        let eventLoop = EmbeddedEventLoop()
-        let promise = eventLoop.makePromise(of: NIOSSHUserAuthenticationOffer?.self)
-        
-        let availableMethods: NIOSSHAvailableUserAuthenticationMethods = [.publicKey, .password]
-        delegate.nextAuthenticationType(availableMethods: availableMethods, nextChallengePromise: promise)
-        
-        let offer = try await promise.futureResult.get()
-        
-        #expect(offer == nil, "Should fail authentication if no credentials are provided.")
+    @Test("Delegate offers public key first when both key and password are available")
+    func testPublicKeyOfferedBeforePassword() throws {
+        let delegate = FlexibleAuthDelegate(username: "test", password: "pw",
+                                            privateKeyString: p256TestKey,
+                                            privateKeyPassphrase: nil)
+        #expect(delegate.privateKey != nil, "Key must parse for this test to be meaningful")
+
+        // Use a real event loop so wait() can deliver the promise synchronously.
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { try? group.syncShutdownGracefully() }
+        let promise = group.next().makePromise(of: NIOSSHUserAuthenticationOffer?.self)
+        delegate.nextAuthenticationType(availableMethods: [.publicKey, .password],
+                                        nextChallengePromise: promise)
+        let offer = try promise.futureResult.wait()
+        #expect(offer?.offer.isPrivateKey == true,
+                "Public-key auth should be offered first")
+    }
+
+    @Test("Delegate offers password when only password auth is available")
+    func testPasswordOfferedWhenOnlyPasswordAvailable() throws {
+        let delegate = FlexibleAuthDelegate(username: "test", password: "pw",
+                                            privateKeyString: nil,
+                                            privateKeyPassphrase: nil)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { try? group.syncShutdownGracefully() }
+        let promise = group.next().makePromise(of: NIOSSHUserAuthenticationOffer?.self)
+        delegate.nextAuthenticationType(availableMethods: [.password],
+                                        nextChallengePromise: promise)
+        let offer = try promise.futureResult.wait()
+        #expect(offer?.offer.isPassword == true)
+    }
+
+    @Test("Delegate returns nil when neither key nor password is available")
+    func testNoCredentialsFails() throws {
+        let delegate = FlexibleAuthDelegate(username: "test", password: nil,
+                                            privateKeyString: nil,
+                                            privateKeyPassphrase: nil)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { try? group.syncShutdownGracefully() }
+        let promise = group.next().makePromise(of: NIOSSHUserAuthenticationOffer?.self)
+        delegate.nextAuthenticationType(availableMethods: [.publicKey, .password],
+                                        nextChallengePromise: promise)
+        let offer = try promise.futureResult.wait()
+        #expect(offer == nil)
     }
 }
 
+// MARK: - PEM Key Logic Tests
+
 @Suite("PEM Key Logic Tests")
 struct PEMKeyLogicTests {
-    // Helper access to methods defined externally in MainView.swift and SSHManager.swift
-    // To access these, we must use the wrapper type provided by `@testable import`.
-    
     @Test("Detects various PEM key kinds")
     func testDetectKeyKind() {
-        // Need to ensure these utility functions are correctly linked via @testable import
         #expect(detectPEMKeyKind("-----BEGIN EC PRIVATE KEY-----") == .ec)
         #expect(detectPEMKeyKind("-----BEGIN PRIVATE KEY-----") == .pkcs8)
         #expect(detectPEMKeyKind("-----BEGIN ENCRYPTED PRIVATE KEY-----") == .pkcs8)
@@ -293,88 +408,80 @@ struct PEMKeyLogicTests {
     }
 }
 
+// MARK: - Connection Model Tests
+
 @Suite("Connection Model Tests")
 struct ConnectionModelTests {
     @Test("Copy method creates a deep, independent copy")
-    func testConnectionCopy() {
-        // 1. Create original connection
-        let originalInfo = ConnectionInfo(name: "Original", serverAddress: "127.0.0.1", portNumber: "22", username: "user", password: "pw", privateKey: "key", privateKeyPassphrase: "pp")
-        let originalTunnel = TunnelInfo(localPort: "8080", remoteServer: "localhost", remotePort: "80")
-        let original = Connection(connectionInfo: originalInfo, tunnelInfo: originalTunnel)
-        
-        // 2. Create a copy
+    @MainActor func testConnectionCopy() {
+        let info = ConnectionInfo(name: "Original", serverAddress: "127.0.0.1",
+                                  portNumber: "22", username: "user",
+                                  password: "pw", privateKey: "key",
+                                  privateKeyPassphrase: "pp")
+        let tunnel = TunnelInfo(localPort: "8080", remoteServer: "localhost", remotePort: "80")
+        let original = Connection(connectionInfo: info, tunnelInfo: tunnel)
+
         let copy = original.copy()
-        
-        // 3. Verify the copy is a new instance, not the same object
-        #expect(original !== copy, "The copied object should be a different instance.")
-        
-        // 4. Verify all properties were copied correctly
+        #expect(original !== copy)
         #expect(original.id == copy.id)
         #expect(original.connectionInfo.name == copy.connectionInfo.name)
         #expect(original.tunnelInfo.localPort == copy.tunnelInfo.localPort)
-        
-        // 5. Modify the copy and verify the original is unchanged
+
         copy.connectionInfo.name = "Modified"
-        #expect(original.connectionInfo.name == "Original", "Modifying the copy's name should not affect the original.")
+        #expect(original.connectionInfo.name == "Original")
         #expect(copy.connectionInfo.name == "Modified")
     }
 }
 
+// MARK: - ConnectionStore Mapping Tests
+
 @Suite("ConnectionStore Mapping Tests")
 struct ConnectionStoreMappingTests {
-    // Use a dummy ConnectionStore instance just to access the mapping methods.
-    // This test does not depend on the store's state or its CloudKit connection.
-    let store = ConnectionStore()
-
-    @Test("CloudKit record mapping round-trip")
-    func testCloudKitMapping() throws {
-        let store = ConnectionStore()
+    @Test("CloudKit record mapping round-trip preserves all fields including ports")
+    @MainActor func testCloudKitMapping() throws {
+        let store = ConnectionStore(mode: .view, connections: [])
         let id = UUID()
-        
-        // Initialize the store on the MainActor, but we only use synchronous helpers here.
-        
-        // 1. Create a source Connection object
-        let connectionInfo = ConnectionInfo(name: "Test Server", serverAddress: "server.example.com", portNumber: "2222", username: "testuser", password: "testpassword", privateKey: "testkey", privateKeyPassphrase: "pp")
-        let tunnelInfo = TunnelInfo(localPort: "9000", remoteServer: "db.internal", remotePort: "5432")
-        let sourceConnection = Connection(id: id, connectionInfo: connectionInfo, tunnelInfo: tunnelInfo)
-        
-        // 2. Create a dummy CKRecord to populate
+
+        let info = ConnectionInfo(name: "Test Server", serverAddress: "server.example.com",
+                                  portNumber: "2222", username: "testuser",
+                                  password: "testpassword", privateKey: "testkey",
+                                  privateKeyPassphrase: "pp")
+        let tunnel = TunnelInfo(localPort: "9000", remoteServer: "db.internal", remotePort: "5432")
+        let source = Connection(id: id, connectionInfo: info, tunnelInfo: tunnel)
+
         let zoneID = CKRecordZone.ID(zoneName: "TestZone", ownerName: CKCurrentUserDefaultName)
-        let recordID = CKRecord.ID(recordName: id.uuidString, zoneID: zoneID)
-        let record = CKRecord(recordType: "Connection", recordID: recordID)
-        
-        // 3. Map Connection -> CKRecord (Saves secrets to Keychain)
-        store.updateRecordFields(record, withConnection: sourceConnection)
-        
-        // 4. Map CKRecord -> Connection (Loads secrets from Keychain)
-        let resultConnection = try #require(store.recordToConnection(record: record))
-        
-        // 5. Assert that the data survived the round-trip
-        #expect(resultConnection.id == sourceConnection.id)
-        #expect(resultConnection.connectionInfo.name == "Test Server")
-        
-        // 6. Verify that secrets were correctly handled via the Keychain
-        #expect(resultConnection.connectionInfo.password == "testpassword")
-        #expect(resultConnection.connectionInfo.privateKey == "testkey")
-        
-        // Clean up the keychain
-        KeychainService.shared.deleteCredentials(for: id)
+        let record = CKRecord(recordType: "Connection",
+                              recordID: CKRecord.ID(recordName: id.uuidString, zoneID: zoneID))
+
+        store.updateRecordFields(record, withConnection: source)
+        record["uuid"] = id.uuidString  // updateRecordFields doesn't set uuid; production code sets it separately
+        let result = try #require(store.recordToConnection(record: record))
+
+        #expect(result.id == source.id)
+        #expect(result.connectionInfo.name == "Test Server")
+        #expect(result.connectionInfo.serverAddress == "server.example.com")
+        #expect(result.connectionInfo.username == "testuser")
+        // Secrets recovered from the mock credentials store
+        #expect(result.connectionInfo.password == "testpassword")
+        #expect(result.connectionInfo.privateKey == "testkey")
+        // Port fields survive the String -> Int64 -> String round-trip
+        #expect(result.connectionInfo.portNumber == "2222")
+        #expect(result.tunnelInfo.localPort == "9000")
+        #expect(result.tunnelInfo.remotePort == "5432")
+        #expect(result.tunnelInfo.remoteServer == "db.internal")
     }
 }
 
+// MARK: - Helpers
 
-// Helper extension to make checking the auth offer type easier in tests
 private extension NIOSSHUserAuthenticationOffer.Offer {
     var isPrivateKey: Bool {
         if case .privateKey = self { return true }
         return false
     }
-    
+
     var isPassword: Bool {
-        if case .password = self {
-            return true
-        }
+        if case .password = self { return true }
         return false
     }
 }
-


### PR DESCRIPTION
Checkpoints the current in-flight work so we have a clean \`Development\` base to branch the Swift API modernization tasks from.

## What's included

**Pass-1 improvements WIP** (commit \`chore: checkpoint pass-1 improvements WIP\`)
- Xcode project settings updates (\`project.pbxproj\`)
- Expanded/rewritten test suite (\`SSH_TunnelBuilderTests.swift\`)
- \`SSHManager\`: \`FlexibleAuthDelegate\` made non-private for test visibility
- Removed the unused \`SSH_TunnelBuilder2\` Core Data model
- Plus the previously committed Ed25519 key initializer fix (\`a1d7fd3\`)

**Modernization roadmap** (commit \`docs: add Swift API modernization roadmap\`)
- New \`MODERNIZATION_ROADMAP.md\` — seven prioritized opportunities to adopt newer Swift/SwiftUI/Foundation/CloudKit APIs, each on its own branch off \`Development\`
- \`CLAUDE.md\` — checklist pointer to the roadmap

## Follow-up

After this merges, the modernization tasks (#1–#7 in the roadmap) each branch off the updated \`Development\`. First up: #3 (\`Task.sleep(for:)\` with \`Duration\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)