### PR TITLE
refactor: @Entry macro for environment key

### DIFF
--- a/SSH TunnelBuilder/GUI/MainView.swift
+++ b/SSH TunnelBuilder/GUI/MainView.swift
@@ -1001,13 +1001,6 @@ struct ConnectButtonView: View {
     }
 }
 
-struct ConnectionEnvironmentKey: EnvironmentKey {
-    static var defaultValue: Connection?
-}
-
 extension EnvironmentValues {
-    var connection: Connection? {
-        get { self[ConnectionEnvironmentKey.self] }
-        set { self[ConnectionEnvironmentKey.self] = newValue }
-    }
+    @Entry var connection: Connection?
 }


### PR DESCRIPTION
Modernization roadmap **task #4** (see \`MODERNIZATION_ROADMAP.md\`).

## Change

\`MainView.swift\` — replaced the manual custom environment key:

\`\`\`swift
struct ConnectionEnvironmentKey: EnvironmentKey {
    static var defaultValue: Connection?
}
extension EnvironmentValues {
    var connection: Connection? {
        get { self[ConnectionEnvironmentKey.self] }
        set { self[ConnectionEnvironmentKey.self] = newValue }
    }
}
\`\`\`

with the \`@Entry\` macro (Xcode 16 / macOS 15):

\`\`\`swift
extension EnvironmentValues {
    @Entry var connection: Connection?
}
\`\`\`

The \`connection\` environment value keeps the same name and \`Connection?\` type (default \`nil\`). This also removes the mutable \`static var defaultValue\`, which warns under Swift 6.

## Verification

- Builds successfully (\`BuildProject\`).
- No new compiler diagnostics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)