### PR TITLE
docs: roadmap task #8 — remove dead connection environment value

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,9 +177,9 @@ priority order (impact, high → low):
   - `Connection` + `ConnectionStore` → `@Observable`; drop `@Published`/Combine; migrate view property wrappers
 - [ ] **2. Native async CloudKit APIs** — `refactor/cloudkit-async-apis` — *High*
   - Replace `withCheckedContinuation` bridging with `record(for:)`, `save(_:)`, `deleteRecord(for:)`, `modifyRecordZones`, `records(matching:)`
-- [ ] **3. `Task.sleep(for:)` with `Duration`** — `refactor/task-sleep-duration` — *Medium*
+- [x] **3. `Task.sleep(for:)` with `Duration`** — `refactor/task-sleep-duration` — *Medium* — merged (PR #35)
   - `ConnectionStore.swift:154`
-- [ ] **4. `@Entry` macro for environment key** — `refactor/entry-macro-environment` — *Medium*
+- [x] **4. `@Entry` macro for environment key** — `refactor/entry-macro-environment` — *Medium* — in review (PR #36)
   - `MainView.swift:1004-1013`
 - [ ] **5. `ByteCountFormatStyle` (`.formatted`)** — `refactor/bytecount-format-style` — *Medium*
   - `DataCounterView.swift`
@@ -187,3 +187,5 @@ priority order (impact, high → low):
   - `ContentView.swift:46`
 - [ ] **7. NIO singleton event-loop group** — `refactor/nio-singleton-eventloop` — *Low (optional)*
   - `SSHManager.swift:511` (review lifecycle before adopting)
+- [ ] **8. Remove dead `connection` environment value** — `refactor/remove-dead-connection-env` — *Low (cleanup)*
+  - `MainView.swift` — `EnvironmentValues.connection` is never read/written; delete it (discovered during #4)

--- a/MODERNIZATION_ROADMAP.md
+++ b/MODERNIZATION_ROADMAP.md
@@ -17,11 +17,12 @@ Deployment target is **macOS 15.6**, so all modern APIs below are available.
 |---|------|--------|--------|--------|
 | 1 | Adopt Observation framework (`@Observable`) | `refactor/observable-macro` | High | Not started |
 | 2 | Native async CloudKit APIs | `refactor/cloudkit-async-apis` | High | Not started |
-| 3 | `Task.sleep(for:)` with `Duration` | `refactor/task-sleep-duration` | Medium | Not started |
-| 4 | `@Entry` macro for environment key | `refactor/entry-macro-environment` | Medium | Not started |
+| 3 | `Task.sleep(for:)` with `Duration` | `refactor/task-sleep-duration` | Medium | Merged (PR #35) |
+| 4 | `@Entry` macro for environment key | `refactor/entry-macro-environment` | Medium | In review (PR #36) |
 | 5 | `ByteCountFormatStyle` (`.formatted`) | `refactor/bytecount-format-style` | Medium | Not started |
 | 6 | Replace `DispatchQueue.main.asyncAfter` | `refactor/async-error-clear` | Low | Not started |
 | 7 | NIO singleton event-loop group | `refactor/nio-singleton-eventloop` | Low | Not started |
+| 8 | Remove dead `connection` environment value | `refactor/remove-dead-connection-env` | Low | Not started |
 
 ---
 
@@ -128,3 +129,23 @@ list. Test against the real CloudKit container.
 
 **Risk:** Behavioral change — the shared singleton must **not** be shut down in
 `shutdown()` (`SSHManager.swift:804-811`). Review lifecycle carefully before adopting.
+
+---
+
+## 8. Remove dead `connection` environment value
+**Branch:** `refactor/remove-dead-connection-env` · **Impact:** Low (cleanup)
+
+The custom `connection` environment value in `MainView.swift` (the
+`EnvironmentValues.connection` declaration, now expressed via `@Entry` after #4)
+is never read or written anywhere in the app — it is dead API. Delete the
+`extension EnvironmentValues { @Entry var connection: Connection? }` entirely.
+
+While here, consider a quick sweep for other unused symbols (e.g.
+`isOpenSSHKeyEncrypted(_:)` in `MainView.swift`, the deprecated `errorAlert(_:)`
+`View` extension in `ContentView.swift`) and remove anything confirmed dead.
+
+> Discovered during #4 — the `@Entry` modernization only restyled code that has
+> no callers. Best done **after** #4 merges so the deletion is a clean, separate diff.
+
+**Risk:** Trivial. Confirm zero references before deleting (`XcodeGrep`/`Grep`),
+then build to verify.


### PR DESCRIPTION
Adds **task #8** to the modernization roadmap: delete the unused
`EnvironmentValues.connection` value in `MainView.swift`, which is never read or
written anywhere in the app (surfaced while doing #4's `@Entry` modernization).

Also refreshes the roadmap/checklist status for #3 (merged, PR #35) and #4 (in review, PR #36).

Docs-only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)