### PR TITLE
refactor: ByteCountFormatStyle via .formatted

### DIFF
--- a/SSH TunnelBuilder/GUI/DataCounterView.swift
+++ b/SSH TunnelBuilder/GUI/DataCounterView.swift
@@ -15,8 +15,8 @@ struct DataCounterView: View {
         VStack {
             HStack {
                 VStack(alignment: .leading) {
-                    Text("Data Sent: \(byteCountFormatter.string(fromByteCount: connection.bytesSent))")
-                    Text("Data Received: \(byteCountFormatter.string(fromByteCount: connection.bytesReceived))")
+                    Text("Data Sent: \(connection.bytesSent.formatted(.byteCount(style: .file)))")
+                    Text("Data Received: \(connection.bytesReceived.formatted(.byteCount(style: .file)))")
                 }
                 Spacer()
                 VStack {
@@ -26,12 +26,6 @@ struct DataCounterView: View {
                 }
             }
         }
-    }
-
-    private var byteCountFormatter: ByteCountFormatter {
-        let formatter = ByteCountFormatter()
-        formatter.countStyle = .file
-        return formatter
     }
 }
 


### PR DESCRIPTION
Modernization roadmap **task #5** (see \`MODERNIZATION_ROADMAP.md\`).

## Change

\`DataCounterView.swift\`:
- \`byteCountFormatter.string(fromByteCount:)\` → \`connection.bytesSent.formatted(.byteCount(style: .file))\` (modern \`ByteCountFormatStyle\`, macOS 13+).
- Removed the now-unused \`byteCountFormatter\` computed property.

Output is unchanged — same \`.file\` count style.

## Verification

- Builds successfully (\`BuildProject\`).
- No new compiler diagnostics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)