### PR TITLE
refactor: replace DispatchQueue.main.asyncAfter with Task.sleep

### DIFF
--- a/SSH TunnelBuilder/GUI/ContentView.swift
+++ b/SSH TunnelBuilder/GUI/ContentView.swift
@@ -43,7 +43,8 @@ struct ContentView: View {
                 errorMessage = error.message
                 showingErrorSheet = true
                 // Clear the error after capturing it
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                Task { @MainActor in
+                    try? await Task.sleep(for: .milliseconds(100))
                     connectionStore.errorAlert = nil
                 }
             }


### PR DESCRIPTION
Modernization roadmap **task #6** (see \`MODERNIZATION_ROADMAP.md\`).

## Change

\`ContentView.swift\` — in the \`errorAlert\` \`onChange\` handler, the deferred clear of \`connectionStore.errorAlert\`:

\`\`\`swift
DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
    connectionStore.errorAlert = nil
}
\`\`\`

becomes:

\`\`\`swift
Task { @MainActor in
    try? await Task.sleep(for: .milliseconds(100))
    connectionStore.errorAlert = nil
}
\`\`\`

Matches the async/await style used across the rest of the codebase. Behavior is unchanged — same ~100 ms delay, still on the main actor (\`connectionStore\` is \`@MainActor\`).

## Verification

- Builds successfully (\`BuildProject\`).
- No new compiler diagnostics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)