### PR TITLE
refactor: remove dead code (connection env value + unused helpers)

### DIFF
--- a/SSH TunnelBuilder/GUI/ContentView.swift
+++ b/SSH TunnelBuilder/GUI/ContentView.swift
@@ -1,19 +1,5 @@
 import SwiftUI
 
-// MARK: - Reusable Error Alert Modifier (deprecated - using sheet instead)
-
-extension View {
-    func errorAlert(_ errorAlert: Binding<ErrorAlert?>) -> some View {
-        self.alert(item: errorAlert) { error in
-            Alert(
-                title: Text("Error"),
-                message: Text(error.message),
-                dismissButton: .default(Text("OK"))
-            )
-        }
-    }
-}
-
 struct ContentView: View {
     @StateObject var connectionStore: ConnectionStore
     @State private var selectedConnection: Connection?

--- a/SSH TunnelBuilder/GUI/MainView.swift
+++ b/SSH TunnelBuilder/GUI/MainView.swift
@@ -39,22 +39,6 @@ func detectPEMKeyKind(_ text: String) -> PEMKeyKind {
     return .unknown
 }
 
-/// Checks if an OpenSSH key is encrypted (has cipher/kdf specified)
-/// OpenSSH keys store encryption info in the binary blob, but we can check for common patterns
-func isOpenSSHKeyEncrypted(_ text: String) -> Bool {
-    // OpenSSH encrypted keys have cipher info in the base64 blob
-    // A simple heuristic: unencrypted keys are shorter and have "none" as cipher
-    // For accurate detection, we'd need to parse the binary format
-    // This is a conservative check - if in doubt, assume it might be encrypted
-    let t = text.trimmingCharacters(in: .whitespacesAndNewlines)
-    guard t.contains("-----BEGIN OPENSSH PRIVATE KEY-----") else { return false }
-
-    // Extract base64 content and decode to check cipher field
-    // For now, we'll rely on the actual parsing to detect this
-    // and just return false here (the parser will throw if encrypted)
-    return false
-}
-
 /// Determines whether a PEM private key is encrypted
 func isPEMEncrypted(_ text: String) -> Bool {
     let t = text.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
@@ -999,8 +983,4 @@ struct ConnectButtonView: View {
         tempPassphrase = ""
         saveCredentials = false
     }
-}
-
-extension EnvironmentValues {
-    @Entry var connection: Connection?
 }


### PR DESCRIPTION
Modernization roadmap **task #8** (see \`MODERNIZATION_ROADMAP.md\`).

Removes three confirmed-dead symbols surfaced during the modernization work:

- **\`EnvironmentValues.connection\`** (\`MainView.swift\`) — the custom environment value (restyled via \`@Entry\` in #4) is never read or written anywhere in the app.
- **\`isOpenSSHKeyEncrypted(_:)\`** (\`MainView.swift\`) — no callers; it unconditionally returned \`false\` (a stub).
- **\`errorAlert(_:)\` \`View\` extension** (\`ContentView.swift\`) — comment-marked "deprecated - using sheet instead"; never applied as a modifier. Error presentation goes through \`ErrorSheetView\`.

## Verification

- No references in the app **or** test target (\`grep\`).
- Builds successfully, including \`buildForTesting\` (test target compiles).
- No new compiler diagnostics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)