### PR TITLE
refactor: use NIO singleton event loop group

### DIFF
--- a/SSH TunnelBuilder/Classes/SSHManager.swift
+++ b/SSH TunnelBuilder/Classes/SSHManager.swift
@@ -508,7 +508,9 @@ final class SSHManager: ObservableObject, @unchecked Sendable {
             throw SSHTunnelError.missingCredentials
         }
 
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        // Use NIO's process-wide singleton event loop group. It is shared across
+        // all connections and must never be shut down (see shutdown()).
+        let group = MultiThreadedEventLoopGroup.singleton
         lock.withLock { self.eventLoopGroup = group }
 
         // 2. Offload auth delegate creation (heavy crypto) to detached task
@@ -801,14 +803,10 @@ final class SSHManager: ObservableObject, @unchecked Sendable {
             self.internalBytesReceived = 0
         }
 
-        if let group = lock.withLock({ self.eventLoopGroup }) {
-            do {
-                try await group.shutdownGracefully()
-            } catch {
-                Logger.error("EventLoopGroup shutdown error: \(error)", log: Logger.ssh)
-            }
-            lock.withLock { self.eventLoopGroup = nil }
-        }
+        // The event loop group is NIO's process-wide singleton, which is perpetual
+        // and must not be shut down. Just drop our reference to it; the channels
+        // were already closed above.
+        lock.withLock { self.eventLoopGroup = nil }
 
         await MainActor.run {
             // Only transition to idle if we're disconnecting normally


### PR DESCRIPTION
Modernization roadmap **task #7** (see \`MODERNIZATION_ROADMAP.md\`).

## Change

\`SSHManager.swift\` — replaces the per-connection group with NIO's process-wide singleton:

- \`MultiThreadedEventLoopGroup(numberOfThreads: 1)\` → \`MultiThreadedEventLoopGroup.singleton\`, avoiding per-connection thread spin-up/teardown. Connections now multiplex over the shared group (standard NIO design).
- \`shutdown()\` no longer calls \`shutdownGracefully()\`. The singleton is perpetual (\`canBeShutDown == .no\`); calling \`shutdownGracefully\` on it resolves with \`EventLoopError.unsupportedOperation\`, which the old code caught and logged as an error on every disconnect. We now simply drop our reference. Channels are still closed on disconnect exactly as before.

## Lifecycle review (the risk called out in the roadmap)

- Verified against the resolved SwiftNIO source: \`MultiThreadedEventLoopGroup.singleton\` → \`NIOSingletons.posixEventLoopGroup\`, constructed with \`canBeShutDown: .no\`.
- The singleton is retained by NIO globally and must never \`deinit\` — we only hold/clear a reference, never own it.
- \`startLocalListener\` reads the same stored group for its \`ServerBootstrap\`; behavior unchanged.

## Verification

- Builds successfully including \`buildForTesting\`.
- One pre-existing Swift 6 \`Sendable\` warning on \`NIOSSHHandler\` (line ~584) is unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)