### PR TITLE
refactor: adopt @Observable for Connection & ConnectionStore

### DIFF
--- a/SSH TunnelBuilder/Classes/Connection.swift
+++ b/SSH TunnelBuilder/Classes/Connection.swift
@@ -1,6 +1,6 @@
 import Foundation
 import CloudKit
-import Combine
+import Observation
 
 struct ConnectionInfo {
     var name: String
@@ -60,15 +60,16 @@ enum ConnectionState: Equatable {
 }
 
 @MainActor
-class Connection: Identifiable, Equatable, Hashable, ObservableObject {
+@Observable
+class Connection: Identifiable, Equatable, Hashable {
     let id: UUID
     let recordID: CKRecord.ID?
-    @Published var connectionInfo: ConnectionInfo
-    @Published var tunnelInfo: TunnelInfo
-    
-    @Published var bytesSent: Int64 = 0
-    @Published var bytesReceived: Int64 = 0
-    @Published var state: ConnectionState = .idle
+    var connectionInfo: ConnectionInfo
+    var tunnelInfo: TunnelInfo
+
+    var bytesSent: Int64 = 0
+    var bytesReceived: Int64 = 0
+    var state: ConnectionState = .idle
 
     /// Convenience: whether the connection is active (connected)
     var isActive: Bool { state.isActive }

--- a/SSH TunnelBuilder/Classes/ConnectionStore.swift
+++ b/SSH TunnelBuilder/Classes/ConnectionStore.swift
@@ -1,5 +1,6 @@
 import Foundation
 import CloudKit
+import Observation
 
 private enum CloudKitKeys {
     static let recordType = "Connection"
@@ -39,7 +40,8 @@ struct HostKeyRequest: Identifiable {
 
 /// Main data store for SSH connections, managing CloudKit sync and local state
 @MainActor // Mark the store to run updates on the MainActor
-class ConnectionStore: ObservableObject {
+@Observable
+class ConnectionStore {
     
     // MARK: - Nested Types
     
@@ -50,27 +52,27 @@ class ConnectionStore: ObservableObject {
         case loading
     }
     
-    @Published var mode: Mode = .loading
-    @Published private(set) var connections: [Connection] = []
-    @Published private(set) var tempConnection: Connection?
-    
-    // Properties for the "Create" form
-    @Published var connectionName = ""
-    @Published var serverAddress = ""
-    @Published var portNumber = ""
-    @Published var username = ""
-    @Published var password = ""
-    @Published var privateKey = ""
-    @Published var localPort = ""
-    @Published var remoteServer = ""
-    @Published var remotePort = ""
-    
-    @Published var migrationNotice: String? = nil
-    @Published var cloudNotice: String? = nil
-    @Published var errorAlert: ErrorAlert? = nil
-    @Published var hostKeyRequest: HostKeyRequest? = nil
+    var mode: Mode = .loading
+    private(set) var connections: [Connection] = []
+    private(set) var tempConnection: Connection?
 
-    private var managers: [UUID: SSHManager] = [:]
+    // Properties for the "Create" form
+    var connectionName = ""
+    var serverAddress = ""
+    var portNumber = ""
+    var username = ""
+    var password = ""
+    var privateKey = ""
+    var localPort = ""
+    var remoteServer = ""
+    var remotePort = ""
+
+    var migrationNotice: String? = nil
+    var cloudNotice: String? = nil
+    var errorAlert: ErrorAlert? = nil
+    var hostKeyRequest: HostKeyRequest? = nil
+
+    @ObservationIgnored private var managers: [UUID: SSHManager] = [:]
 
     /// Credentials storage (Keychain in production, mock for tests)
     private let credentialsStore: CredentialsStore
@@ -84,7 +86,7 @@ class ConnectionStore: ObservableObject {
 
     private let container = CKContainer(identifier: ConnectionStore.containerIdentifier)
     private let database = CKContainer(identifier: ConnectionStore.containerIdentifier).privateCloudDatabase
-    private var customZone: CKRecordZone?
+    @ObservationIgnored private var customZone: CKRecordZone?
     private let customZoneName = "ConnectionZone"
 
     private let migrationNotifiedKey = "MigratedCredentialsNotified"

--- a/SSH TunnelBuilder/Classes/SSHManager.swift
+++ b/SSH TunnelBuilder/Classes/SSHManager.swift
@@ -2,7 +2,6 @@ import Foundation
 import NIO
 @preconcurrency import NIOSSH
 import CryptoKit
-import Combine
 
 // NOTE: PEMKeyKind, detectPEMKeyKind, isPEMEncrypted are assumed to be defined in MainView.swift or another file.
 // If they are not visible here, move them to a shared utility file.
@@ -450,7 +449,7 @@ private extension FlexibleAuthDelegate {
 
 // MARK: - SSHManager
 
-final class SSHManager: ObservableObject, @unchecked Sendable {
+final class SSHManager: @unchecked Sendable {
     /// Connection timeout in seconds. Increase for high-latency networks.
     static var connectionTimeoutSeconds: Int64 = 10
 
@@ -466,7 +465,7 @@ final class SSHManager: ObservableObject, @unchecked Sendable {
     private var sessionReadyPromise: EventLoopPromise<Void>?
     private var sessionReadyCompleted = false
 
-    @Published var lastErrorMessage: String? = nil
+    var lastErrorMessage: String? = nil
     
     private var internalBytesSent: Int64 = 0
     private var internalBytesReceived: Int64 = 0

--- a/SSH TunnelBuilder/GUI/ContentView.swift
+++ b/SSH TunnelBuilder/GUI/ContentView.swift
@@ -1,13 +1,13 @@
 import SwiftUI
 
 struct ContentView: View {
-    @StateObject var connectionStore: ConnectionStore
+    @State private var connectionStore: ConnectionStore
     @State private var selectedConnection: Connection?
     @State private var showingErrorSheet = false
     @State private var errorMessage = ""
 
     init(connectionStore: ConnectionStore) {
-        _connectionStore = StateObject(wrappedValue: connectionStore)
+        _connectionStore = State(initialValue: connectionStore)
     }
 
     var body: some View {
@@ -17,11 +17,11 @@ struct ContentView: View {
                 selectedConnection: $selectedConnection,
                 mode: $connectionStore.mode
             )
-            .environmentObject(connectionStore)
+            .environment(connectionStore)
             .accessibilityIdentifier("NavigationList")
         } detail: {
             MainView(selectedConnection: $selectedConnection)
-                .environmentObject(connectionStore)
+                .environment(connectionStore)
                 .accessibilityIdentifier("MainView")
         }
         .onChange(of: connectionStore.errorAlert) { _, newValue in

--- a/SSH TunnelBuilder/GUI/DataCounterView.swift
+++ b/SSH TunnelBuilder/GUI/DataCounterView.swift
@@ -9,7 +9,7 @@ import Foundation
 import SwiftUI
 
 struct DataCounterView: View {
-    @ObservedObject var connection: Connection
+    var connection: Connection
 
     var body: some View {
         VStack {

--- a/SSH TunnelBuilder/GUI/MainView.swift
+++ b/SSH TunnelBuilder/GUI/MainView.swift
@@ -139,7 +139,7 @@ struct EditableFieldView: View {
     let placeholder: String
     let isSecure: Bool
     
-    @EnvironmentObject private var connectionStore: ConnectionStore
+    @Environment(ConnectionStore.self) private var connectionStore
 
     init(value: Binding<String>, placeholder: String, isSecure: Bool = false) {
         self.value = value
@@ -368,7 +368,7 @@ struct KeyValidationAlertView: View {
 // MARK: - Main View
 
 struct MainView: View {
-    @EnvironmentObject var connectionStore: ConnectionStore
+    @Environment(ConnectionStore.self) var connectionStore
     
     @Binding var selectedConnection: Connection?
         
@@ -460,7 +460,7 @@ struct MainView: View {
                     HStack {
                         if connectionStore.mode == .view, let connection = selectedConnection {
                             ConnectButtonView(connection: connection)
-                                .environmentObject(connectionStore)
+                                .environment(connectionStore)
                                 .padding()
                         } else {
                             Button(action: {
@@ -518,7 +518,10 @@ struct MainView: View {
     ) -> Binding<String> {
         switch connectionStore.mode {
         case .create:
-            return $connectionStore[dynamicMember: createKeyPath]
+            return Binding(
+                get: { connectionStore[keyPath: createKeyPath] },
+                set: { connectionStore[keyPath: createKeyPath] = $0 }
+            )
         case .edit:
             return Binding(
                 get: {
@@ -703,7 +706,7 @@ struct MainView: View {
 }
 
 struct ConnectionIndicatorView: View {
-    @ObservedObject var connection: Connection
+    var connection: Connection
 
     private var statusColor: Color {
         switch connection.state {
@@ -745,8 +748,8 @@ struct ConnectionIndicatorView: View {
 }
 
 struct ConnectButtonView: View {
-    @ObservedObject var connection: Connection
-    @EnvironmentObject var connectionStore: ConnectionStore
+    var connection: Connection
+    @Environment(ConnectionStore.self) var connectionStore
     @State private var showCredentialsSheet: Bool = false
     @State private var tempPassword: String = ""
     @State private var tempPrivateKey: String = ""

--- a/SSH TunnelBuilder/GUI/NavigationView.swift
+++ b/SSH TunnelBuilder/GUI/NavigationView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct NavigationList: View {
-    @ObservedObject var connectionStore: ConnectionStore
+    var connectionStore: ConnectionStore
     @Binding var selectedConnection: Connection?
     @Binding var mode: ConnectionStore.Mode
     

--- a/SSH TunnelBuilder/SSH_TunnelBuilderApp.swift
+++ b/SSH TunnelBuilder/SSH_TunnelBuilderApp.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 @main
 struct SSH_TunnelBuilderApp: App {
-    @StateObject private var connectionStore = ConnectionStore()
+    @State private var connectionStore = ConnectionStore()
 
     var body: some Scene {
         WindowGroup {


### PR DESCRIPTION
Modernization roadmap **task #1** (see \`MODERNIZATION_ROADMAP.md\`) — the last one.

Migrates the view models from \`ObservableObject\`/\`@Published\` to the **Observation framework** (\`@Observable\`), removing the Combine dependency and giving finer-grained view updates.

## Changes

**Models / store**
- \`Connection\` → \`@Observable\`; dropped all \`@Published\`; \`import Combine\` → \`import Observation\`.
- \`ConnectionStore\` → \`@Observable\`; dropped all 15 \`@Published\`; \`import Observation\`. Internal mutable state (\`managers\`, \`customZone\`) marked \`@ObservationIgnored\` since it isn't view state.

**Views**
- \`@StateObject\` → \`@State\` (\`SSH_TunnelBuilderApp\`, \`ContentView\` — init now uses \`State(initialValue:)\`).
- \`@ObservedObject\` → plain stored property (\`DataCounterView\`, \`NavigationList\`, \`ConnectionIndicatorView\`, \`ConnectButtonView\`).
- \`@EnvironmentObject\` → \`@Environment(ConnectionStore.self)\` and \`.environmentObject(_)\` → \`.environment(_)\` (\`ContentView\`, \`MainView\`, \`EditableFieldView\`, \`ConnectButtonView\`).
- \`MainView\` create-mode form binding: \`$connectionStore[dynamicMember:]\` isn't available from \`@Environment\`, so it's rebuilt as a manual \`Binding(get:set:)\` over the existing \`ReferenceWritableKeyPath\` — consistent with the edit/view cases that already capture the store in their binding closures.

**SSHManager** (the roadmap's deliberate exception)
- Not an \`@Observable\` fit: it's \`@unchecked Sendable\` and mutated off the main actor. Its \`lastErrorMessage\` is never observed by any view (verified), so \`ObservableObject\`/\`@Published\` and the Combine import were dropped outright rather than converted.

## Verification

- App **and** test targets build, including \`buildForTesting\`. No new compiler diagnostics.
- Confirmed zero remaining \`ObservableObject\`/\`@Published\`/\`@StateObject\`/\`@ObservedObject\`/\`@EnvironmentObject\`/\`.environmentObject\`/\`import Combine\` in the app target.
- No Combine publisher (\`objectWillChange\`/\`.$\`) usage existed to break.
- ⚠️ Unit tests still can't **execute** on this machine due to the pre-existing Swift Testing runner crash (\`Runner._applyScopingTraits\`) documented in #42 — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)