### PR TITLE
docs: record Swift Testing runner crash as a known beta-toolchain blocker

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,19 +173,47 @@ Full details and per-task notes live in [`MODERNIZATION_ROADMAP.md`](MODERNIZATI
 Each task ships on its own branch off `Development` with its own PR. Listed in
 priority order (impact, high → low):
 
-- [ ] **1. Adopt Observation framework (`@Observable`)** — `refactor/observable-macro` — *High*
-  - `Connection` + `ConnectionStore` → `@Observable`; drop `@Published`/Combine; migrate view property wrappers
-- [ ] **2. Native async CloudKit APIs** — `refactor/cloudkit-async-apis` — *High*
-  - Replace `withCheckedContinuation` bridging with `record(for:)`, `save(_:)`, `deleteRecord(for:)`, `modifyRecordZones`, `records(matching:)`
+All eight tasks are merged into `Development`:
+
+- [x] **1. Adopt Observation framework (`@Observable`)** — `refactor/observable-macro` — *High* — merged (PR #43)
+- [x] **2. Native async CloudKit APIs** — `refactor/cloudkit-async-apis` — *High* — merged (PR #42), using `recordZoneChanges(inZoneWith:since:)` (kept the zone-changes approach to avoid the queryable-index bug)
 - [x] **3. `Task.sleep(for:)` with `Duration`** — `refactor/task-sleep-duration` — *Medium* — merged (PR #35)
-  - `ConnectionStore.swift:154`
-- [x] **4. `@Entry` macro for environment key** — `refactor/entry-macro-environment` — *Medium* — in review (PR #36)
-  - `MainView.swift:1004-1013`
-- [ ] **5. `ByteCountFormatStyle` (`.formatted`)** — `refactor/bytecount-format-style` — *Medium*
-  - `DataCounterView.swift`
-- [ ] **6. Replace `DispatchQueue.main.asyncAfter`** — `refactor/async-error-clear` — *Low*
-  - `ContentView.swift:46`
-- [ ] **7. NIO singleton event-loop group** — `refactor/nio-singleton-eventloop` — *Low (optional)*
-  - `SSHManager.swift:511` (review lifecycle before adopting)
-- [ ] **8. Remove dead `connection` environment value** — `refactor/remove-dead-connection-env` — *Low (cleanup)*
-  - `MainView.swift` — `EnvironmentValues.connection` is never read/written; delete it (discovered during #4)
+- [x] **4. `@Entry` macro for environment key** — `refactor/entry-macro-environment` — *Medium* — merged (PR #36)
+- [x] **5. `ByteCountFormatStyle` (`.formatted`)** — `refactor/bytecount-format-style` — *Medium* — merged (PR #38)
+- [x] **6. Replace `DispatchQueue.main.asyncAfter`** — `refactor/async-error-clear` — *Low* — merged (PR #39)
+- [x] **7. NIO singleton event-loop group** — `refactor/nio-singleton-eventloop` — *Low* — merged (PR #41)
+- [x] **8. Remove dead `connection` environment value** — `refactor/remove-dead-connection-env` — *Low (cleanup)* — merged (PR #40)
+
+---
+
+## Known Issues
+
+### Test suite cannot run reliably on the macOS 26/27 beta toolchain (2026-06-15)
+
+**Symptom:** Running the test bundle crashes the test host in Swift Testing's
+`Runner._applyScopingTraits(for:testCase:_:)`. With the default (parallel)
+configuration *no* tests run at all — every suite reports
+`Crash: ... Runner._applyScopingTraits` before any test body executes, and the
+host hits "Exceeded max restart count". No `.ips` crash report is produced.
+
+**Diagnosis:** This is a Swift Testing **runtime** bug in the current
+Xcode-beta / macOS 27.0 (26A5353q) toolchain, not a defect in the test code or
+target configuration:
+- The test code is plain, idiomatic Swift Testing (no custom/scoping traits).
+- The test target settings are standard (`SWIFT_DEFAULT_ACTOR_ISOLATION = nonisolated`, Swift 6, hosted by the app).
+- It reproduces on a clean `Development` checkout, independent of the `@Observable`/CloudKit modernization work.
+- Behaviour scales with concurrency: 1–6 tests run fine in isolation; the full 30-test run crashes. It is also non-deterministic — the crashing test moves between runs.
+
+**Attempted workarounds (not adopted):** Serializing every suite (`.serialized`
+roots) plus disabling `SWIFT_APPROACHABLE_CONCURRENCY` on the test target raised
+the pass count from 0 to ~20–28/30, but runs still aborted non-deterministically
+partway through. We chose **not** to ship a flaky partial workaround. A couple of
+P256 EC-key-parsing `AuthDelegate` tests also appear to crash in isolation —
+possibly a genuine parser bug, but it's entangled with the runtime instability
+and can't be cleanly isolated while the runner itself is unstable.
+
+**Action:** Revisit when the Xcode/macOS toolchain updates (re-run the full
+suite; if it's green by default, this entry can be removed). If the EC-parsing
+tests still crash once the runner is stable, investigate
+`FlexibleAuthDelegate.parsePrivateKey` / `PEMDecryptor` for the `EC PRIVATE KEY`
+(SEC1) path as a separate bug.

--- a/MODERNIZATION_ROADMAP.md
+++ b/MODERNIZATION_ROADMAP.md
@@ -15,14 +15,19 @@ Deployment target is **macOS 15.6**, so all modern APIs below are available.
 
 | # | Task | Branch | Impact | Status |
 |---|------|--------|--------|--------|
-| 1 | Adopt Observation framework (`@Observable`) | `refactor/observable-macro` | High | Not started |
-| 2 | Native async CloudKit APIs | `refactor/cloudkit-async-apis` | High | Not started |
+| 1 | Adopt Observation framework (`@Observable`) | `refactor/observable-macro` | High | Merged (PR #43) |
+| 2 | Native async CloudKit APIs | `refactor/cloudkit-async-apis` | High | Merged (PR #42) |
 | 3 | `Task.sleep(for:)` with `Duration` | `refactor/task-sleep-duration` | Medium | Merged (PR #35) |
-| 4 | `@Entry` macro for environment key | `refactor/entry-macro-environment` | Medium | In review (PR #36) |
-| 5 | `ByteCountFormatStyle` (`.formatted`) | `refactor/bytecount-format-style` | Medium | Not started |
-| 6 | Replace `DispatchQueue.main.asyncAfter` | `refactor/async-error-clear` | Low | Not started |
-| 7 | NIO singleton event-loop group | `refactor/nio-singleton-eventloop` | Low | Not started |
-| 8 | Remove dead `connection` environment value | `refactor/remove-dead-connection-env` | Low | Not started |
+| 4 | `@Entry` macro for environment key | `refactor/entry-macro-environment` | Medium | Merged (PR #36) |
+| 5 | `ByteCountFormatStyle` (`.formatted`) | `refactor/bytecount-format-style` | Medium | Merged (PR #38) |
+| 6 | Replace `DispatchQueue.main.asyncAfter` | `refactor/async-error-clear` | Low | Merged (PR #39) |
+| 7 | NIO singleton event-loop group | `refactor/nio-singleton-eventloop` | Low | Merged (PR #41) |
+| 8 | Remove dead `connection` environment value | `refactor/remove-dead-connection-env` | Low | Merged (PR #40) |
+
+> **All tasks complete.** Note: task #2 was implemented with the async
+> `recordZoneChanges(inZoneWith:since:)` rather than `records(matching:)` — the
+> fetch path uses CloudKit zone changes specifically to avoid the queryable-index
+> requirement, so `records(matching:)` would have reintroduced that bug.
 
 ---
 


### PR DESCRIPTION
Per discussion, we're **not** shipping a code workaround for the test-runner crash — it's a Swift Testing runtime bug in the current Xcode-beta / macOS 27 (26A5353q) toolchain. This PR documents it instead and refreshes the modernization checklist.

## Investigation summary

- Running the test bundle crashes the host in `Runner._applyScopingTraits(for:testCase:_:)`. By default **no tests run** — every suite reports the crash before any test body executes; the host hits "Exceeded max restart count". No `.ips` crash report is produced.
- **Not a code/config bug:** test code is plain idiomatic Swift Testing (no custom traits); the target config is standard (`SWIFT_DEFAULT_ACTOR_ISOLATION = nonisolated`, Swift 6, hosted by the app); it reproduces on a clean `Development` checkout, independent of the `@Observable`/CloudKit work.
- **Scales with concurrency:** 1–6 tests pass in isolation; the full 30-test run crashes, non-deterministically (the crashing test moves between runs).
- **Attempted workarounds (not adopted):** serializing every suite + disabling `SWIFT_APPROACHABLE_CONCURRENCY` raised the pass count from 0 to ~20–28/30, but runs still aborted partway through. A flaky partial workaround isn't worth committing.
- A couple of P256 EC-key-parsing `AuthDelegate` tests also appear to crash in isolation — possibly a real parser bug, but entangled with the runtime instability; flagged for separate investigation once the runner is stable.

## Changes (docs only)

- New **Known Issues** section in `CLAUDE.md` with the diagnosis and a revisit plan (re-run after the toolchain updates; if green, delete the entry).
- Refreshed the modernization checklist — all 8 tasks are now merged (PRs #35, #36, #38–#43).

No source or build-setting changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)