### PR TITLE
refactor: make SSHManager NIO handlers Swift 6 concurrency-clean

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,8 +207,22 @@ strict concurrency surfaced almost nothing):**
 - `SSHManager.swift` — added `import NIOFoundationCompat`; member-import-visibility
   now requires the explicit import for `ByteBuffer(data:)`.
 
-Both targets build clean (regular + build-for-testing), zero warnings. The test
-suite was not re-run — still blocked by the Swift Testing runner crash below.
+**NIO handler concurrency warnings (10, all in `SSHManager`):** the language-mode
+bump surfaced strict-concurrency *warnings* (not errors) in the relay/handler code.
+Fixed so the app target is warning-free:
+- `GenericRelayHandler` — marked `@unchecked Sendable` (event-loop-confined,
+  immutable stored state), constrained `OutboundType: Sendable`, and the
+  `eventLoop.execute { }` closures now capture `peer`/`outboundData` instead of
+  `self`. `onBytes`/`transform` (and the `received`/`sent` call sites) are now
+  `@Sendable`.
+- `channelInitializer` — replaced the `addHandler(...).flatMap { addHandler(...) }`
+  chain (which captured non-`Sendable` handlers in an escaping `@Sendable` closure)
+  with `eventLoop.makeCompletedFuture { try pipeline.syncOperations.addHandlers([...]) }`.
+
+Both targets build clean (regular + build-for-testing) with **zero warnings**
+(verified via per-file diagnostics). The test suite was not re-run — still blocked
+by the Swift Testing runner crash below, so the SSH data-path changes are
+compile-validated but not behaviourally tested on this toolchain.
 
 ---
 

--- a/SSH TunnelBuilder/Classes/SSHManager.swift
+++ b/SSH TunnelBuilder/Classes/SSHManager.swift
@@ -75,14 +75,20 @@ private extension TaskGroup where ChildTaskResult == Void {
     }
 }
 
-private final class GenericRelayHandler<InboundType, OutboundType>: ChannelInboundHandler {
+// `@unchecked Sendable`: a `ChannelHandler` is confined to its channel's event
+// loop, and every stored property here is immutable. NIO's pipeline APIs require
+// `Sendable` handlers under Swift 6, so we vouch for the confinement explicitly.
+// `OutboundType: Sendable` lets the transformed value cross into the peer's
+// event-loop closure without warning (the concrete types are `ByteBuffer` and
+// `SSHChannelData`, both `Sendable`).
+private final class GenericRelayHandler<InboundType, OutboundType: Sendable>: ChannelInboundHandler, @unchecked Sendable {
     typealias InboundIn = InboundType
 
     private let peer: Channel
-    private let onBytes: (Int) -> Void
-    private let transform: (InboundType) -> (OutboundType?, Int)
+    private let onBytes: @Sendable (Int) -> Void
+    private let transform: @Sendable (InboundType) -> (OutboundType?, Int)
 
-    init(peer: Channel, onBytes: @escaping (Int) -> Void, transform: @escaping (InboundType) -> (OutboundType?, Int)) {
+    init(peer: Channel, onBytes: @escaping @Sendable (Int) -> Void, transform: @escaping @Sendable (InboundType) -> (OutboundType?, Int)) {
         self.peer = peer
         self.onBytes = onBytes
         self.transform = transform
@@ -94,10 +100,12 @@ private final class GenericRelayHandler<InboundType, OutboundType>: ChannelInbou
 
         if count > 0 {
             self.onBytes(count)
-            if let outboundData = outboundData {
+            if let outboundData {
                 // Ensure write happens on the peer's event loop for thread safety.
+                // Capture `peer` (Sendable) rather than `self`.
+                let peer = self.peer
                 peer.eventLoop.execute {
-                    self.peer.writeAndFlush(outboundData, promise: nil)
+                    peer.writeAndFlush(outboundData, promise: nil)
                 }
             }
         }
@@ -105,8 +113,9 @@ private final class GenericRelayHandler<InboundType, OutboundType>: ChannelInbou
 
     func channelInactive(context: ChannelHandlerContext) {
         // Ensure close happens on the peer's event loop for thread safety.
+        let peer = self.peer
         peer.eventLoop.execute {
-            self.peer.close(mode: .all, promise: nil)
+            peer.close(mode: .all, promise: nil)
         }
         context.fireChannelInactive()
     }
@@ -114,8 +123,9 @@ private final class GenericRelayHandler<InboundType, OutboundType>: ChannelInbou
     func errorCaught(context: ChannelHandlerContext, error: Error) {
         Logger.error("GenericRelayHandler error: \(error)", log: Logger.ssh)
         // Ensure close happens on the peer's event loop for thread safety.
+        let peer = self.peer
         peer.eventLoop.execute {
-            self.peer.close(mode: .all, promise: nil)
+            peer.close(mode: .all, promise: nil)
         }
         context.close(promise: nil)
     }
@@ -571,20 +581,24 @@ final class SSHManager: @unchecked Sendable {
         let bootstrap = ClientBootstrap(group: group)
             .channelOption(ChannelOptions.connectTimeout, value: .seconds(Self.connectionTimeoutSeconds))
             .channelInitializer { channel in
-                let clientConfig = SSHClientConfiguration(userAuthDelegate: authDelegate,
-                                                          serverAuthDelegate: serverDelegate)
-                let sshHandler = NIOSSHHandler(
-                    role: .client(clientConfig),
-                    allocator: channel.allocator,
-                    inboundChildChannelInitializer: nil
-                )
-                guard let sessionReadyPromise = self.sessionReadyPromise else {
-                    return channel.eventLoop.makeFailedFuture(SSHTunnelError.internalError("Missing sessionReadyPromise"))
-                }
-                let sessionReadyHandler = SSHSessionReadyHandler(sessionReadyPromise: sessionReadyPromise)
-                
-                return channel.pipeline.addHandler(sshHandler).flatMap {
-                    return channel.pipeline.addHandler(sessionReadyHandler)
+                // The initializer runs on the channel's event loop, so add the
+                // handlers synchronously. This keeps the (non-Sendable) NIO
+                // handlers out of an escaping @Sendable closure, which the
+                // previous `addHandler(...).flatMap { addHandler(...) }` chain
+                // required under Swift 6.
+                channel.eventLoop.makeCompletedFuture {
+                    let clientConfig = SSHClientConfiguration(userAuthDelegate: authDelegate,
+                                                              serverAuthDelegate: serverDelegate)
+                    let sshHandler = NIOSSHHandler(
+                        role: .client(clientConfig),
+                        allocator: channel.allocator,
+                        inboundChildChannelInitializer: nil
+                    )
+                    guard let sessionReadyPromise = self.sessionReadyPromise else {
+                        throw SSHTunnelError.internalError("Missing sessionReadyPromise")
+                    }
+                    let sessionReadyHandler = SSHSessionReadyHandler(sessionReadyPromise: sessionReadyPromise)
+                    try channel.pipeline.syncOperations.addHandlers([sshHandler, sessionReadyHandler])
                 }
             }
 
@@ -752,7 +766,7 @@ final class SSHManager: @unchecked Sendable {
     
     // New helper method extracted from the inner closure in startLocalListener()
     private func configureSSHChildPipeline(_ sshChildChannel: Channel, inbound: Channel, strongSelf: SSHManager) -> EventLoopFuture<Void> {
-        let received: (Int) -> Void = { [weak strongSelf] n in
+        let received: @Sendable (Int) -> Void = { [weak strongSelf] n in
             guard let manager = strongSelf else { return }
             Task { @MainActor in manager.handleBytesReceived(n) }
         }
@@ -764,7 +778,7 @@ final class SSHManager: @unchecked Sendable {
     }
 
     private func configureInboundTCPPipeline(_ inbound: Channel, sshChildChannel: Channel, strongSelf: SSHManager) -> EventLoopFuture<Void> {
-        let sent: (Int) -> Void = { [weak strongSelf] n in
+        let sent: @Sendable (Int) -> Void = { [weak strongSelf] n in
             guard let manager = strongSelf else { return }
             Task { @MainActor in manager.handleBytesSent(n) }
         }


### PR DESCRIPTION
## Summary

Follow-up to #45 (Swift 6 language mode). The language-mode bump left **10 strict-concurrency warnings** (not errors) in `SSHManager`'s NIO relay/handler code. This PR resolves them so the app target is **warning-free** under Swift 6.

## Changes

- **`GenericRelayHandler`** — marked `@unchecked Sendable` (the handler is event-loop-confined and all stored state is immutable), constrained `OutboundType: Sendable`, and the `eventLoop.execute { }` closures now capture `peer`/`outboundData` locally instead of `self`. `onBytes`/`transform` and their `received`/`sent` call sites are now `@Sendable`.
- **`channelInitializer`** — replaced the `addHandler(...).flatMap { addHandler(...) }` chain (which captured non-`Sendable` NIO handlers in an escaping `@Sendable` closure) with `eventLoop.makeCompletedFuture { try channel.pipeline.syncOperations.addHandlers([...]) }`. The initializer already runs on the channel's event loop, so synchronous pipeline ops are safe and avoid the capture entirely.

## Testing

- ✅ Builds clean (regular + build-for-testing), **zero warnings**, verified via per-file diagnostics.
- ⚠️ Behaviour not test-validated: these touch the SSH data path, and the documented Swift Testing runner crash on the macOS 27 beta toolchain still blocks the suite. Changes are semantically equivalent (same handlers, same ordering, same event-loop threading).

🤖 Generated with [Claude Code](https://claude.com/claude-code)