### PR TITLE
feat: opt-in Spotlight indexing for connections

### DIFF
--- a/SSH TunnelBuilder/Classes/ConnectionStore.swift
+++ b/SSH TunnelBuilder/Classes/ConnectionStore.swift
@@ -400,6 +400,10 @@ class ConnectionStore {
         } else {
             self.connections.append(connection)
         }
+        // Keep Spotlight in sync (no-op unless the user has opted in). This is the
+        // single choke point for additions/updates, so it covers create, edit,
+        // and each record restored during a fetch.
+        SpotlightIndexer.index(connection)
     }
 
     private func updateConnectionAsync(_ connection: Connection, connectionToUpdate: Connection) async {
@@ -507,6 +511,9 @@ class ConnectionStore {
         self.disconnect(connection)
         self.managers[connection.id] = nil
         credentialsStore.deleteCredentials(for: connection.id)
+        // Remove from Spotlight regardless of opt-in state, so a deleted
+        // connection never lingers in the system index.
+        SpotlightIndexer.deindex(id: connection.id)
         
         guard let recordID = connection.recordID else {
             // Connection exists only locally (no CloudKit record yet)

--- a/SSH TunnelBuilder/Classes/Logger.swift
+++ b/SSH TunnelBuilder/Classes/Logger.swift
@@ -15,6 +15,7 @@ enum Logger {
     static let keychain = Category(logger: os.Logger(subsystem: subsystem, category: "Keychain"))
     static let cloudKit = Category(logger: os.Logger(subsystem: subsystem, category: "CloudKit"))
     static let crypto = Category(logger: os.Logger(subsystem: subsystem, category: "Crypto"))
+    static let spotlight = Category(logger: os.Logger(subsystem: subsystem, category: "Spotlight"))
 
     // MARK: - Convenience Methods
 

--- a/SSH TunnelBuilder/Classes/SpotlightIndexer.swift
+++ b/SSH TunnelBuilder/Classes/SpotlightIndexer.swift
@@ -1,0 +1,91 @@
+import Foundation
+import CoreSpotlight
+import UniformTypeIdentifiers
+
+/// Donates SSH connections to Core Spotlight so the user can find them from
+/// system-wide search.
+///
+/// **Opt-in and privacy-conscious by design.** This app is an SSH connection
+/// manager, so the connection list is effectively infrastructure inventory:
+/// - Nothing is indexed unless the user explicitly turns the feature on in
+///   Settings (`isEnabled`, defaulting to `false`).
+/// - Only the connection's *name* is indexed — never the hostname, username,
+///   port, private key, or any other credential. Secrets live in the Keychain
+///   and are never donated to the system-wide Spotlight index.
+enum SpotlightIndexer {
+    /// Shared domain for every donated connection, so the whole set can be
+    /// cleared in a single call when the user opts out.
+    static let domainIdentifier = "no.comraich.sshTunnelBuilder.connections"
+
+    /// `UserDefaults` key backing the Settings toggle. Shared with the
+    /// `@AppStorage` binding in `SettingsView` so both read the same source.
+    static let enabledDefaultsKey = "spotlightIndexingEnabled"
+
+    /// Whether the user has opted in to Spotlight indexing. Defaults to `false`.
+    static var isEnabled: Bool {
+        UserDefaults.standard.bool(forKey: enabledDefaultsKey)
+    }
+
+    // MARK: - Indexing
+
+    /// Indexes a single connection (name only). No-op unless the user opted in.
+    @MainActor
+    static func index(_ connection: Connection) {
+        guard isEnabled else { return }
+        donate([item(id: connection.id, name: connection.connectionInfo.name)])
+    }
+
+    /// Re-indexes the full set of connections. Used when the user first enables
+    /// the feature so existing connections become searchable immediately.
+    @MainActor
+    static func indexAll(_ connections: [Connection]) {
+        guard isEnabled else { return }
+        let items = connections.map { item(id: $0.id, name: $0.connectionInfo.name) }
+        guard !items.isEmpty else { return }
+        donate(items)
+    }
+
+    // MARK: - De-indexing
+
+    /// Removes a single connection from the index. Runs regardless of the
+    /// opt-in state so a deleted connection never lingers in Spotlight.
+    static func deindex(id: UUID) {
+        CSSearchableIndex.default().deleteSearchableItems(withIdentifiers: [id.uuidString]) { error in
+            if let error {
+                Logger.error("Spotlight de-index failed: \(error.localizedDescription)", log: Logger.spotlight)
+            }
+        }
+    }
+
+    /// Removes every donated connection. Used when the user disables the feature.
+    static func deindexAll() {
+        CSSearchableIndex.default().deleteSearchableItems(withDomainIdentifiers: [domainIdentifier]) { error in
+            if let error {
+                Logger.error("Spotlight clear-all failed: \(error.localizedDescription)", log: Logger.spotlight)
+            }
+        }
+    }
+
+    // MARK: - Private
+
+    /// Builds a searchable item carrying only the connection name. Extracting
+    /// `id`/`name` here keeps the (non-`Sendable`) `Connection` out of the
+    /// escaping completion handler.
+    private static func item(id: UUID, name: String) -> CSSearchableItem {
+        let attributes = CSSearchableItemAttributeSet(contentType: .content)
+        attributes.title = name
+        attributes.displayName = name
+        // Intentionally no host / username / port — see the type-level note.
+        return CSSearchableItem(uniqueIdentifier: id.uuidString,
+                                domainIdentifier: domainIdentifier,
+                                attributeSet: attributes)
+    }
+
+    private static func donate(_ items: [CSSearchableItem]) {
+        CSSearchableIndex.default().indexSearchableItems(items) { error in
+            if let error {
+                Logger.error("Spotlight index failed: \(error.localizedDescription)", log: Logger.spotlight)
+            }
+        }
+    }
+}

--- a/SSH TunnelBuilder/GUI/ContentView.swift
+++ b/SSH TunnelBuilder/GUI/ContentView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import CoreSpotlight
 
 struct ContentView: View {
     @State private var connectionStore: ConnectionStore
@@ -23,6 +24,16 @@ struct ContentView: View {
             MainView(selectedConnection: $selectedConnection)
                 .environment(connectionStore)
                 .accessibilityIdentifier("MainView")
+        }
+        .onContinueUserActivity(CSSearchableItemActionType) { activity in
+            // The user tapped one of our connections in Spotlight: select it.
+            guard
+                let identifier = activity.userInfo?[CSSearchableItemActivityIdentifier] as? String,
+                let uuid = UUID(uuidString: identifier),
+                let match = connectionStore.connections.first(where: { $0.id == uuid })
+            else { return }
+            connectionStore.mode = .view
+            selectedConnection = match
         }
         .onChange(of: connectionStore.errorAlert) { _, newValue in
             if let error = newValue {

--- a/SSH TunnelBuilder/GUI/SettingsView.swift
+++ b/SSH TunnelBuilder/GUI/SettingsView.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+
+/// App preferences (opened with ⌘,). Currently hosts the opt-in Spotlight
+/// indexing control.
+struct SettingsView: View {
+    @Environment(ConnectionStore.self) private var connectionStore
+    @AppStorage(SpotlightIndexer.enabledDefaultsKey) private var spotlightEnabled = false
+
+    var body: some View {
+        Form {
+            Section {
+                Toggle("Show connections in Spotlight", isOn: $spotlightEnabled)
+                Text("When enabled, your connection **names** become searchable from system-wide Spotlight so you can jump straight to a connection. Only the name is indexed — never the hostname, username, port, or any credential.")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            } header: {
+                Text("Spotlight")
+            }
+        }
+        .formStyle(.grouped)
+        .frame(width: 460)
+        .onChange(of: spotlightEnabled) { _, isOn in
+            // Bring the index in line with the new preference immediately:
+            // donate the current set when turning on, clear it all when off.
+            if isOn {
+                SpotlightIndexer.indexAll(connectionStore.connections)
+            } else {
+                SpotlightIndexer.deindexAll()
+            }
+        }
+    }
+}
+
+#Preview {
+    SettingsView()
+        .environment(ConnectionStore(mode: .view, connections: SampleData.connections))
+}

--- a/SSH TunnelBuilder/SSH_TunnelBuilderApp.swift
+++ b/SSH TunnelBuilder/SSH_TunnelBuilderApp.swift
@@ -8,5 +8,10 @@ struct SSH_TunnelBuilderApp: App {
         WindowGroup {
             ContentView(connectionStore: connectionStore)
         }
+
+        Settings {
+            SettingsView()
+                .environment(connectionStore)
+        }
     }
 }


### PR DESCRIPTION
## Summary

Adds a **privacy-conscious, opt-in** Spotlight integration so users can find saved connections from system-wide search.

Because this app is an SSH connection manager, the connection list is effectively infrastructure inventory. So the feature is **off by default** and deliberately conservative about what it exposes.

## What it does

- **`SpotlightIndexer`** — donates/removes `CSSearchableItem`s. Indexes the connection **name only** — never the hostname, username, port, private key, or any credential. Secrets stay in the Keychain and are never donated.
- **Settings scene (⌘,)** — a "Show connections in Spotlight" toggle (`@AppStorage`, defaults off). Turning it on indexes the current set; turning it off clears all donated items.
- **`ConnectionStore`** — keeps the index in sync at its mutation choke points: `upsertConnection` indexes (no-op unless opted in), `deleteConnection` de-indexes regardless of opt-in state so deleted connections never linger.
- **`ContentView`** — `onContinueUserActivity(CSSearchableItemActionType)` selects the tapped connection.
- **`Logger`** — adds a `Spotlight` category.

## Privacy notes

- Only the user-chosen connection **name** is indexed. Hostnames/usernames/ports are intentionally excluded — searching by hostname won't match, by design.
- Nothing is written to the system index unless the user explicitly opts in.

## Testing

- ✅ Builds clean in Swift 6 mode; the new files add zero warnings (verified via per-file diagnostics).
- ⚠️ Test suite not run — blocked by the documented Swift Testing runner crash on this beta toolchain.

> Note: pre-existing `SSHManager` NIO concurrency warnings are addressed separately in #46, not here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)