### PR TITLE
refactor: remove dead code

### DIFF
--- a/SSH TunnelBuilder/Classes/Connection.swift
+++ b/SSH TunnelBuilder/Classes/Connection.swift
@@ -45,18 +45,6 @@ enum ConnectionState: Equatable {
         if case .disconnecting = self { return true }
         return false
     }
-
-    /// Whether the connection is in a failed state
-    var isFailed: Bool {
-        if case .failed = self { return true }
-        return false
-    }
-
-    /// Error message if in failed state, nil otherwise
-    var errorMessage: String? {
-        if case .failed(let message) = self { return message }
-        return nil
-    }
 }
 
 @MainActor

--- a/SSH TunnelBuilder/Classes/PEMDecryptor.swift
+++ b/SSH TunnelBuilder/Classes/PEMDecryptor.swift
@@ -203,20 +203,6 @@ struct PEMDecryptor {
         return res
     }
     
-    private static func aes256cbcDecrypt(ciphertext: Data, key: Data, iv: Data) throws -> Data {
-        return try AESCBC.decrypt(ciphertext: ciphertext, key: key, iv: iv)
-    }
-    
-    private static func pkcs7Unpad(_ data: Data) throws -> Data {
-        guard let last = data.last else { throw PEMDecryptorError.decryptionFailed }
-        let paddingLen = Int(last)
-        guard paddingLen > 0 && paddingLen <= 16 else { throw PEMDecryptorError.decryptionFailed }
-        let paddingStart = data.count - paddingLen
-        guard paddingStart >= 0 else { throw PEMDecryptorError.decryptionFailed }
-        let padding = data[paddingStart..<data.count]
-        guard padding.allSatisfy({ $0 == last }) else { throw PEMDecryptorError.decryptionFailed }
-        return data.prefix(paddingStart)
-    }
 }
 
 // AES-256-CBC with PKCS#7 padding (no ECB, no raw/NoPadding).
@@ -301,13 +287,6 @@ private struct ASN1Parser {
         let b = data[offset]
         offset += 1
         return b
-    }
-    
-    mutating func peekByte() throws -> UInt8 {
-        guard offset < data.count else {
-            throw PEMDecryptorError.asn1ParseError("Unexpected end of data")
-        }
-        return data[offset]
     }
     
     mutating func peekTag() throws -> UInt8? {

--- a/SSH TunnelBuilder/Classes/PEMDecryptor.swift
+++ b/SSH TunnelBuilder/Classes/PEMDecryptor.swift
@@ -3,7 +3,7 @@ import CryptoKit
 import CommonCrypto
 
 enum PEMKey {
-    case rsa(n: Data, e: Data, d: Data, p: Data, q: Data, dP: Data, dQ: Data, qInv: Data)
+    case rsa
     case ec(curveOID: String, privateScalar: Data)
 }
 
@@ -81,8 +81,7 @@ struct PEMDecryptor {
         let key = try pbkdf2(password: Data(passphrase.utf8),
                              salt: salt,
                              iterations: iterationCount,
-                             keyLength: keyLen,
-                             variant: .sha256)
+                             keyLength: keyLen)
         
         guard key.count == 32 else { throw PEMDecryptorError.decryptionFailed }
         guard iv.count == 16 else { throw PEMDecryptorError.decryptionFailed }
@@ -112,19 +111,9 @@ struct PEMDecryptor {
         if !seq.isAtEnd { _ = try? seq.readAny() }
 
         if algOID == "1.2.840.113549.1.1.1" { // rsaEncryption
-            // RSAPrivateKey (PKCS#1) inside the OCTET STRING
-            var inner = try ASN1Parser(data: pkOctets)
-            var rsaseq = try inner.readSequence()
-            _ = try rsaseq.readInteger() // version
-            let n = try rsaseq.readIntegerBytes()
-            let e = try rsaseq.readIntegerBytes()
-            let d = try rsaseq.readIntegerBytes()
-            let p = try rsaseq.readIntegerBytes()
-            let q = try rsaseq.readIntegerBytes()
-            let dP = try rsaseq.readIntegerBytes()
-            let dQ = try rsaseq.readIntegerBytes()
-            let qInv = try rsaseq.readIntegerBytes()
-            return .rsa(n: n, e: e, d: d, p: p, q: q, dP: dP, dQ: dQ, qInv: qInv)
+            // RSA is detected only so callers can reject it; the key material
+            // is never used, so we don't parse the RSAPrivateKey contents.
+            return .rsa
         } else if algOID == "1.2.840.10045.2.1" { // id-ecPublicKey
             // ECPrivateKey inside the OCTET STRING: SEQUENCE { version, privateKey OCTET STRING, [0] params OPTIONAL, [1] publicKey OPTIONAL }
             var inner = try ASN1Parser(data: pkOctets)
@@ -156,31 +145,18 @@ struct PEMDecryptor {
         return base64Content
     }
     
-    private enum HashVariant {
-        case sha1, sha256
-    }
-    
-    private static func pbkdf2(password: Data, salt: Data, iterations: Int, keyLength: Int, variant: HashVariant) throws -> Data {
+    /// PBKDF2-HMAC-SHA256. The encrypted-PKCS#8 path rejects any other PRF, so
+    /// only SHA-256 is supported here.
+    private static func pbkdf2(password: Data, salt: Data, iterations: Int, keyLength: Int) throws -> Data {
         guard iterations > 0 && keyLength > 0 else { throw PEMDecryptorError.kdfError }
-        
-        let hLen: Int
-        switch variant {
-        case .sha1: hLen = 20
-        case .sha256: hLen = 32
-        }
-        
+
+        let hLen = 32 // HMAC-SHA256 output size
+
         func hmac(_ key: Data, _ data: Data) -> Data {
-            let keySym = SymmetricKey(data: key)
-            switch variant {
-            case .sha1:
-                let mac = HMAC<Insecure.SHA1>.authenticationCode(for: data, using: keySym)
-                return Data(mac)
-            case .sha256:
-                let mac = HMAC<SHA256>.authenticationCode(for: data, using: keySym)
-                return Data(mac)
-            }
+            let mac = HMAC<SHA256>.authenticationCode(for: data, using: SymmetricKey(data: key))
+            return Data(mac)
         }
-        
+
         var derivedKey = Data()
         let blockCount = UInt32((keyLength + hLen - 1) / hLen)
         for i in 1...blockCount {
@@ -376,20 +352,6 @@ private struct ASN1Parser {
         let anyData = data[(offset-2-length)..<(offset+length)]
         offset += length
         return try ASN1Parser(data: anyData)
-    }
-    
-    mutating func readIntegerBytes() throws -> Data {
-        let tag = try readByte()
-        guard tag == 0x02 else {
-            throw PEMDecryptorError.asn1ParseError("Expected INTEGER (tag 0x02), got \(String(format:"0x%02X",tag))")
-        }
-        let length = try readLength()
-        guard offset + length <= data.count else {
-            throw PEMDecryptorError.asn1ParseError("INTEGER length exceeds data")
-        }
-        let intData = data[offset..<offset+length]
-        offset += length
-        return intData
     }
     
     private func parseInteger(_ data: Data) throws -> Int {

--- a/SSH TunnelBuilder/Classes/SSHManager.swift
+++ b/SSH TunnelBuilder/Classes/SSHManager.swift
@@ -163,8 +163,6 @@ internal enum OpenSSHKeyParser {
 
     static func extractOpenSSHData(from pem: String) throws -> Data { return try FlexibleAuthDelegate.extractOpenSSHData(from: pem) }
     static func parseOpenSSHPrivateKey(_ data: Data) throws -> NIOSSHPrivateKey { return try FlexibleAuthDelegate.parseOpenSSHPrivateKey(data) }
-    static func normalizeScalar(_ bytes: [UInt8], targetSize: Int) throws -> Data { return try FlexibleAuthDelegate.normalizeScalar(bytes, targetSize: targetSize) }
-    static func readSSHString(from buffer: inout ByteBuffer) throws -> String { return try FlexibleAuthDelegate.readSSHString(from: &buffer) }
     static func readSSHBytes(from buffer: inout ByteBuffer) throws -> [UInt8] { return try FlexibleAuthDelegate.readSSHBytes(from: &buffer) }
 }
 
@@ -478,11 +476,6 @@ final class SSHManager: @unchecked Sendable {
     private var sessionReadyPromise: EventLoopPromise<Void>?
     private var sessionReadyCompleted = false
 
-    var lastErrorMessage: String? = nil
-    
-    private var internalBytesSent: Int64 = 0
-    private var internalBytesReceived: Int64 = 0
-    
     // Callback: (hostname, fingerprint, keyType, keyData, completion)
     var hostKeyValidationCallback: (@Sendable (String, String, String, Data, @escaping @Sendable (Bool) -> Void) -> Void)?
 
@@ -546,7 +539,6 @@ final class SSHManager: @unchecked Sendable {
         if let initError = authDelegate.initializationError {
             let errorMsg = "Failed to parse private key: \(initError)"
             await MainActor.run {
-                self.lastErrorMessage = errorMsg
                 connection.state = .failed(errorMsg)
                 self.errorCallback?(errorMsg)
             }
@@ -559,7 +551,6 @@ final class SSHManager: @unchecked Sendable {
             let errorMsg = "Failed to initialize key: \(detail). If this is an OpenSSH encrypted key, remove the passphrase or convert to PKCS#8/Ed25519/ECDSA."
 
             await MainActor.run {
-                self.lastErrorMessage = errorMsg
                 connection.state = .failed(errorMsg)
                 self.errorCallback?(errorMsg)
             }
@@ -613,7 +604,6 @@ final class SSHManager: @unchecked Sendable {
             lock.withLock { self.sshClientChannel = channel }
             await MainActor.run {
                 self.connection.state = .connected
-                self.lastErrorMessage = nil
             }
 
             try await startLocalListener()
@@ -815,8 +805,6 @@ final class SSHManager: @unchecked Sendable {
             }
             self.sessionReadyPromise = nil
             self.sessionReadyCompleted = false
-            self.internalBytesSent = 0
-            self.internalBytesReceived = 0
         }
 
         // The event loop group is NIO's process-wide singleton, which is perpetual
@@ -836,7 +824,6 @@ final class SSHManager: @unchecked Sendable {
             // If state is .failed, preserve it for UI display
             self.connection.bytesSent = 0
             self.connection.bytesReceived = 0
-            self.lastErrorMessage = nil
         }
     }
     
@@ -844,15 +831,13 @@ final class SSHManager: @unchecked Sendable {
     
     private func handleBytesSent(_ count: Int) {
         let n = Int64(count)
-        self.internalBytesSent += n
         Task { @MainActor in
             self.connection.bytesSent += n
         }
     }
-    
+
     private func handleBytesReceived(_ count: Int) {
         let n = Int64(count)
-        self.internalBytesReceived += n
         Task { @MainActor in
             self.connection.bytesReceived += n
         }

--- a/SSH TunnelBuilder/GUI/ContentView.swift
+++ b/SSH TunnelBuilder/GUI/ContentView.swift
@@ -96,8 +96,6 @@ struct ErrorSheetView: View {
     }
 }
 
-// Moved to ConnectionStore.swift as it's used there primarily
-
 #Preview("Empty State") {
     ContentView(connectionStore: ConnectionStore(mode: .view, connections: []))
 }

--- a/SSH TunnelBuilder/GUI/MainView.swift
+++ b/SSH TunnelBuilder/GUI/MainView.swift
@@ -652,10 +652,6 @@ struct MainView: View {
         }
     }
 
-    func changeMode(to newMode: ConnectionStore.Mode) {
-        connectionStore.mode = newMode
-    }
-    
     // MARK: - Helper Views
     
     private var loadingView: some View {

--- a/SSH TunnelBuilder/GUI/MainView.swift
+++ b/SSH TunnelBuilder/GUI/MainView.swift
@@ -132,7 +132,6 @@ struct CommandHelpRow: View {
 }
 
 // MARK: - Editable Field View
-// MARK: - Editable Field View
 
 struct EditableFieldView: View {
     let value: Binding<String>

--- a/SSH TunnelBuilder/GUI/NavigationView.swift
+++ b/SSH TunnelBuilder/GUI/NavigationView.swift
@@ -58,8 +58,4 @@ struct NavigationList: View {
             }
         }
     }
-    
-    func deleteConnection(_ connection: Connection) {
-        connectionStore.deleteConnection(connection)
-    }
 }

--- a/SSH TunnelBuilderTests/SSH_TunnelBuilderTests.swift
+++ b/SSH TunnelBuilderTests/SSH_TunnelBuilderTests.swift
@@ -81,23 +81,6 @@ struct ConnectionStateTests {
         #expect(!ConnectionState.failed("err").isDisconnecting)
     }
 
-    @Test("isFailed is true only when failed")
-    func isFailedOnlyWhenFailed() {
-        #expect(!ConnectionState.idle.isFailed)
-        #expect(!ConnectionState.connecting.isFailed)
-        #expect(!ConnectionState.connected.isFailed)
-        #expect(!ConnectionState.disconnecting.isFailed)
-        #expect(ConnectionState.failed("err").isFailed)
-    }
-
-    @Test("errorMessage carries the failure reason")
-    func errorMessageCarriesReason() {
-        let reason = "Connection refused"
-        #expect(ConnectionState.failed(reason).errorMessage == reason)
-        #expect(ConnectionState.idle.errorMessage == nil)
-        #expect(ConnectionState.connected.errorMessage == nil)
-    }
-
     @Test("States with equal associated values compare equal")
     func equalityWithAssociatedValues() {
         #expect(ConnectionState.failed("a") == ConnectionState.failed("a"))


### PR DESCRIPTION
## Summary

Removes dead code identified by a dead-code audit of the app target. No behavioural changes — every item had no remaining call sites in the app or test targets (or was unreachable).

### Commit 1 — unreferenced functions & write-only properties
- `NavigationList.deleteConnection(_:)` — toolbar calls the store directly
- `MainView.changeMode(to:)` — views set `connectionStore.mode` inline
- `PEMDecryptor.aes256cbcDecrypt` / `pkcs7Unpad` — `AESCBC.decrypt` is used directly
- `ASN1Parser.peekByte()` — only `peekTag()` is used
- `OpenSSHKeyParser.normalizeScalar` / `readSSHString` wrappers — unused shims
- `SSHManager.lastErrorMessage` — UI surfaces errors via `errorCallback`
- `SSHManager.internalBytesSent` / `internalBytesReceived` — UI reads `connection.bytes*`

### Commit 2 — unreachable / unused code paths
- PBKDF2: dropped the unreachable HMAC-SHA1 path (the encrypted-PKCS#8 reader already rejects any non-SHA256 PRF); `pbkdf2` now hardcodes SHA-256
- RSA: `PEMKey.rsa` loses its unused associated values; RSA is detected only to be rejected, so the key material is no longer parsed — making `ASN1Parser.readIntegerBytes()` dead (removed)
- `ConnectionState.isFailed` / `errorMessage` removed (used only by tests) along with their two unit tests
- Removed stale comments

## Testing
Builds clean (regular + build-for-testing) with zero warnings.

⚠️ The unit suite was **not executed** — per the project's Known Issues, the Swift Testing runner is unstable on the current macOS 26/27 beta toolchain. Changes are compile-validated only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)