### PR TITLE
fix: SEC1 EC PRIVATE KEY parsing + ASN.1 slice-indexing crash

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -247,13 +247,17 @@ target configuration:
 **Attempted workarounds (not adopted):** Serializing every suite (`.serialized`
 roots) plus disabling `SWIFT_APPROACHABLE_CONCURRENCY` on the test target raised
 the pass count from 0 to ~20–28/30, but runs still aborted non-deterministically
-partway through. We chose **not** to ship a flaky partial workaround. A couple of
-P256 EC-key-parsing `AuthDelegate` tests also appear to crash in isolation —
-possibly a genuine parser bug, but it's entangled with the runtime instability
-and can't be cleanly isolated while the runner itself is unstable.
+partway through. We chose **not** to ship a flaky partial workaround.
 
 **Action:** Revisit when the Xcode/macOS toolchain updates (re-run the full
-suite; if it's green by default, this entry can be removed). If the EC-parsing
-tests still crash once the runner is stable, investigate
-`FlexibleAuthDelegate.parsePrivateKey` / `PEMDecryptor` for the `EC PRIVATE KEY`
-(SEC1) path as a separate bug.
+suite; if it's green by default, this entry can be removed).
+
+> **EC-key-parsing crash — root-caused and fixed (2026-06-15).** The `AuthDelegate`
+> EC crashes were a genuine parser bug, *not* the runner instability:
+> `ASN1Parser` indexed `data[offset]` from 0, but every sub-parser was built from
+> a Foundation `Data` **slice**, which keeps its parent's indices — so the first
+> read on any sub-parser indexed below `startIndex` and trapped. Fixed by rebasing
+> the input to a zero-based copy in `ASN1Parser.init` (`Data(data)`). The same fix
+> enabled top-level SEC1 `EC PRIVATE KEY` parsing (see `parseSEC1ECPrivateKey`).
+> Verified via `RunCodeSnippet`: OpenSSH Ed25519/ECDSA, PKCS#8 EC (plain +
+> encrypted), and SEC1 P-256/384/521 all parse.

--- a/SSH TunnelBuilder/Classes/PEMDecryptor.swift
+++ b/SSH TunnelBuilder/Classes/PEMDecryptor.swift
@@ -98,15 +98,6 @@ struct PEMDecryptor {
         _ = try seq.readInteger() // version
         var alg = try seq.readSequence()
         let algOID = try alg.readOID()
-        var curveOID: String? = nil
-        if !alg.isAtEnd {
-            // parameters could be NULL, OID (for EC), or a sequence
-            if let tag = try alg.peekTag(), tag == 0x06 {
-                curveOID = try alg.readOID()
-            } else {
-                _ = try? alg.readAny()
-            }
-        }
         let pkOctets = try seq.readOctetString()
         if !seq.isAtEnd { _ = try? seq.readAny() }
 
@@ -115,16 +106,28 @@ struct PEMDecryptor {
             // is never used, so we don't parse the RSAPrivateKey contents.
             return .rsa
         } else if algOID == "1.2.840.10045.2.1" { // id-ecPublicKey
-            // ECPrivateKey inside the OCTET STRING: SEQUENCE { version, privateKey OCTET STRING, [0] params OPTIONAL, [1] publicKey OPTIONAL }
-            var inner = try ASN1Parser(data: pkOctets)
-            var ecseq = try inner.readSequence()
-            _ = try ecseq.readInteger() // version
-            let priv = try ecseq.readOctetString()
-            // params may be present as [0] EXPLICIT OID, but we already captured curveOID from AlgorithmIdentifier
-            return .ec(curveOID: curveOID ?? "", privateScalar: priv)
+            // The privateKey OCTET STRING wraps a SEC1 ECPrivateKey structure.
+            return try parseSEC1ECPrivateKey(pkOctets)
         } else {
             throw PEMDecryptorError.unsupportedFormat
         }
+    }
+
+    /// Parses a SEC1 `ECPrivateKey` (RFC 5915) and returns its private scalar.
+    /// Used both for top-level `EC PRIVATE KEY` PEMs and for the inner key blob
+    /// of a PKCS#8 EC `PrivateKeyInfo` (which is itself a SEC1 ECPrivateKey).
+    ///
+    /// ECPrivateKey ::= SEQUENCE { version INTEGER, privateKey OCTET STRING,
+    ///                             [0] parameters OPTIONAL, [1] publicKey OPTIONAL }
+    ///
+    /// The curve is identified by the caller from the scalar length, so the
+    /// optional namedCurve parameters are not read here.
+    static func parseSEC1ECPrivateKey(_ der: Data) throws -> PEMKey {
+        var asn1 = try ASN1Parser(data: der)
+        var seq = try asn1.readSequence()
+        _ = try seq.readInteger() // version (1)
+        let scalar = try seq.readOctetString()
+        return .ec(curveOID: "", privateScalar: scalar)
     }
     
     private static func extractEncryptedPrivateKeyBase64(from pem: String) throws -> String {
@@ -249,7 +252,12 @@ private struct ASN1Parser {
     private var offset: Int = 0
 
     init(data: Data) throws {
-        self.data = data
+        // Foundation `Data` slices keep their parent's indices, but this parser
+        // indexes from 0 (e.g. `data[offset]`). Sub-parsers are always built
+        // from slices (`data[offset..<…]`), so rebase to a zero-based copy —
+        // otherwise the first read on a sub-parser indexes below `startIndex`
+        // and traps. This was the root cause of the EC-key parsing crashes.
+        self.data = Data(data)
     }
     
     var isAtEnd: Bool {

--- a/SSH TunnelBuilder/Classes/SSHManager.swift
+++ b/SSH TunnelBuilder/Classes/SSHManager.swift
@@ -255,8 +255,14 @@ private extension FlexibleAuthDelegate {
             throw PEMDecryptorError.invalidPEM
         }
         
-        let parsedKey = try PEMDecryptor.parsePKCS8PrivateKey(derData)
-        
+        // A `.ec` kind here is a top-level SEC1 `EC PRIVATE KEY` (unencrypted);
+        // its DER is a bare SEC1 ECPrivateKey, not a PKCS#8 PrivateKeyInfo, so
+        // it needs the SEC1 parser. Everything else (`BEGIN PRIVATE KEY` and any
+        // decrypted PKCS#8 blob) is PKCS#8.
+        let parsedKey = (kind == .ec)
+            ? try PEMDecryptor.parseSEC1ECPrivateKey(derData)
+            : try PEMDecryptor.parsePKCS8PrivateKey(derData)
+
         switch parsedKey {
         case .ec(_, let privateScalar):
             switch privateScalar.count {

--- a/SSH TunnelBuilderTests/SSH_TunnelBuilderTests.swift
+++ b/SSH TunnelBuilderTests/SSH_TunnelBuilderTests.swift
@@ -289,10 +289,47 @@ struct AuthDelegateTests {
     -----END EC PRIVATE KEY-----
     """
 
-    @Test("Delegate initializes with a valid unencrypted ECDSA P-256 key")
+    /// SEC1 `EC PRIVATE KEY` (RFC 5915) for the P-384 curve.
+    let p384TestKey = """
+    -----BEGIN EC PRIVATE KEY-----
+    MIGkAgEBBDDgU65GwW8KYZzGCFK0/QlqCskB8AXooHh/aSy9WfxKVkfXh3Tx/S+K
+    1S4mexrXOMqgBwYFK4EEACKhZANiAATml2B9CXVZ1cd9qBqVoNDXTuQ9+CzXnhZF
+    SkpLY034jzg2u7wKq5kAcHg0sxo3AWdpf9qjHaGsihqB7KLxpHhiKhdIR3o0eW/b
+    PsePEY/O7/KpGBRLC69Msyl/eTfTIDg=
+    -----END EC PRIVATE KEY-----
+    """
+
+    /// SEC1 `EC PRIVATE KEY` (RFC 5915) for the P-521 curve.
+    let p521TestKey = """
+    -----BEGIN EC PRIVATE KEY-----
+    MIHcAgEBBEIAkvmBqlPwmCaehCIZrBRmpHa8PDBH/q2hRi3e8l80H8RU3jRHJQk5
+    m5wczKcnwNUAHObbqzJyLZ7oBgw12iWKPiSgBwYFK4EEACOhgYkDgYYABADDq70e
+    k/nw6fP36G/ONCk/KKyG3W2ie674awBwDANSocngQbpa5uuAt6CzNJ64zrRHVqsO
+    8UHJa1ZhZAfuQdbZ3wEudsiLfOcogcONYsKOs2gi+L4BTPnExN2TUlrbomDXizUT
+    vyGPHesrZpoxhNoSMFqFlt9NnfIDblMNEU7JkRC63A==
+    -----END EC PRIVATE KEY-----
+    """
+
+    @Test("Delegate initializes with a valid unencrypted ECDSA P-256 SEC1 key")
     func testValidUnencryptedECKeyInitialization() {
         let delegate = FlexibleAuthDelegate(username: "test", password: nil,
                                             privateKeyString: p256TestKey,
+                                            privateKeyPassphrase: nil)
+        #expect(delegate.privateKey != nil)
+    }
+
+    @Test("Delegate initializes with a valid unencrypted ECDSA P-384 SEC1 key")
+    func testValidUnencryptedP384KeyInitialization() {
+        let delegate = FlexibleAuthDelegate(username: "test", password: nil,
+                                            privateKeyString: p384TestKey,
+                                            privateKeyPassphrase: nil)
+        #expect(delegate.privateKey != nil)
+    }
+
+    @Test("Delegate initializes with a valid unencrypted ECDSA P-521 SEC1 key")
+    func testValidUnencryptedP521KeyInitialization() {
+        let delegate = FlexibleAuthDelegate(username: "test", password: nil,
+                                            privateKeyString: p521TestKey,
                                             privateKeyPassphrase: nil)
         #expect(delegate.privateKey != nil)
     }


### PR DESCRIPTION
## Summary

The credentials UI lists **`EC PRIVATE KEY`** (SEC1 / RFC 5915) as a supported format, but those keys never parsed — and attempting to parse *any* EC key could **crash the app** (SIGTRAP). This fixes both.

## Root cause

`ASN1Parser` indexes `data[offset]` starting at 0, but every sub-parser is constructed from a Foundation `Data` **slice** (`data[offset..<…]`), and `Data` slices keep their parent's indices. So the first read on a sub-parser indexed below `startIndex` and trapped in `Data._Representation.subscript`. Top-level keys (from `Data(base64Encoded:)`) are zero-based and survived until the first `readSequence` — which is exactly where EC parsing lands. This is the "EC parsing crashes" item in CLAUDE.md's Known Issues, now root-caused.

## Fixes

- **`ASN1Parser.init`** rebases its input to a zero-based copy (`Data(data)`), making every sub-parser slice-safe. Also hardens the deeply-nested encrypted-PKCS#8 path.
- **`PEMDecryptor.parseSEC1ECPrivateKey`** added for top-level SEC1 keys; the PKCS#8 EC branch now reuses it (its inner key blob is itself a SEC1 `ECPrivateKey`).
- **`FlexibleAuthDelegate.parsePrivateKey`** routes unencrypted `.ec` keys to the SEC1 parser; everything else stays PKCS#8.
- Added **P-384 / P-521 SEC1** unit-test vectors.

## Context: NIOSSH key support

NIOSSH 0.13.0 supports exactly Ed25519 + ECDSA P-256/384/521 (no RSA/DSA), so this completes EC *format* coverage for the curves the library can actually use. Remaining known gaps (separate, not in this PR): Ed25519-in-PKCS#8, and encrypted OpenSSH keys.

## Testing

Builds clean (regular + build-for-testing). The Swift Testing runner is still unstable on this macOS 27 beta toolchain, so behaviour was verified with `RunCodeSnippet` against real `openssl`/`ssh-keygen` keys:

| Format | Result |
|---|---|
| OpenSSH Ed25519 / ECDSA | ✅ |
| PKCS#8 EC (plain) | ✅ |
| PKCS#8 EC (encrypted) | ✅ |
| SEC1 P-256 / P-384 / P-521 | ✅ (previously crashed) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)