### PR TITLE
feat: support Ed25519 private keys in PKCS#8 format

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,12 +35,12 @@ Supported private-key formats (all for Ed25519 / ECDSA only):
 | Format | Plain | Encrypted |
 |---|---|---|
 | OpenSSH (`openssh-key-v1`) | ✅ | ✅ bcrypt + aes128/192/256-ctr |
-| PKCS#8 (`BEGIN PRIVATE KEY`) | ✅ (EC only) | ✅ EC only, PBES2/PBKDF2-SHA256/AES-256-CBC |
+| PKCS#8 (`BEGIN PRIVATE KEY`) | ✅ (EC + Ed25519) | ✅ EC + Ed25519, PBES2/PBKDF2-SHA256/AES-256-CBC |
 | SEC1 (`BEGIN EC PRIVATE KEY`) | ✅ | — |
 
-Known gaps (not yet implemented): Ed25519 in PKCS#8 (OID 1.3.101.112); encrypted
-OpenSSH AES-CBC and AEAD ciphers (chacha20-poly1305, aes-gcm) — only AES-CTR is
-handled; broader PKCS#8 ciphers/KDFs.
+Known gaps (not yet implemented): encrypted OpenSSH AES-CBC and AEAD ciphers
+(chacha20-poly1305, aes-gcm) — only AES-CTR is handled; broader PKCS#8
+ciphers/KDFs.
 
 ---
 

--- a/SSH TunnelBuilder/Classes/PEMDecryptor.swift
+++ b/SSH TunnelBuilder/Classes/PEMDecryptor.swift
@@ -5,6 +5,7 @@ import CommonCrypto
 enum PEMKey {
     case rsa
     case ec(curveOID: String, privateScalar: Data)
+    case ed25519(seed: Data)
 }
 
 enum PEMDecryptorError: Error {
@@ -108,6 +109,15 @@ struct PEMDecryptor {
         } else if algOID == "1.2.840.10045.2.1" { // id-ecPublicKey
             // The privateKey OCTET STRING wraps a SEC1 ECPrivateKey structure.
             return try parseSEC1ECPrivateKey(pkOctets)
+        } else if algOID == "1.3.101.112" { // id-Ed25519 (RFC 8410)
+            // The privateKey OCTET STRING wraps a CurvePrivateKey, which is
+            // itself an OCTET STRING holding the 32-byte seed (04 20 || seed).
+            var inner = try ASN1Parser(data: pkOctets)
+            let seed = try inner.readOctetString()
+            guard seed.count == 32 else {
+                throw PEMDecryptorError.asn1ParseError("Ed25519 seed must be 32 bytes, got \(seed.count)")
+            }
+            return .ed25519(seed: Data(seed))
         } else {
             throw PEMDecryptorError.unsupportedFormat
         }

--- a/SSH TunnelBuilder/Classes/SSHManager.swift
+++ b/SSH TunnelBuilder/Classes/SSHManager.swift
@@ -275,6 +275,9 @@ private extension FlexibleAuthDelegate {
             default:
                 throw SSHTunnelError.unsupportedCurveLength
             }
+        case .ed25519(let seed):
+            let key = try Curve25519.Signing.PrivateKey(rawRepresentation: seed)
+            return NIOSSHPrivateKey(ed25519Key: key)
         case .rsa:
             throw SSHTunnelError.rsaNotSupported
         }

--- a/SSH TunnelBuilder/GUI/MainView.swift
+++ b/SSH TunnelBuilder/GUI/MainView.swift
@@ -822,7 +822,7 @@ struct ConnectButtonView: View {
 
                                 Text("Supported:")
                                     .font(.subheadline)
-                                Text("• Ed25519 (OpenSSH format)")
+                                Text("• Ed25519 (OpenSSH or PKCS#8 format)")
                                     .font(.footnote)
                                 Text("• ECDSA P-256/P-384/P-521 (OpenSSH, EC PRIVATE KEY, or PKCS#8)")
                                     .font(.footnote)

--- a/SSH TunnelBuilderTests/SSH_TunnelBuilderTests.swift
+++ b/SSH TunnelBuilderTests/SSH_TunnelBuilderTests.swift
@@ -335,6 +335,51 @@ struct AuthDelegateTests {
         #expect(delegate.privateKey != nil)
     }
 
+    /// Ed25519 in unencrypted PKCS#8 (`openssl genpkey -algorithm ed25519`).
+    let ed25519PKCS8 = """
+    -----BEGIN PRIVATE KEY-----
+    MC4CAQAwBQYDK2VwBCIEIDmuqa3zNPAT5I/FSnGkNz1s/wt3l9o4S9TBBhOu8i8+
+    -----END PRIVATE KEY-----
+    """
+
+    /// The same Ed25519 key in encrypted PKCS#8 (AES-256-CBC + PBKDF2-SHA256). Passphrase: "hunter2".
+    let ed25519PKCS8Encrypted = """
+    -----BEGIN ENCRYPTED PRIVATE KEY-----
+    MIGjMF8GCSqGSIb3DQEFDTBSMDEGCSqGSIb3DQEFDDAkBBD9rdog5l0MTvoeuws0
+    PF9oAgIIADAMBggqhkiG9w0CCQUAMB0GCWCGSAFlAwQBKgQQIlViEFefceB0/UR7
+    P60BqARAV81TF7jGD3f2x0B6uxoyX0/PmZdSEEV02RbOjrOgKW+J8imN5qycvcks
+    pZ4oKLZTaxou5tErgSM6rJcxO2H15Q==
+    -----END ENCRYPTED PRIVATE KEY-----
+    """
+
+    @Test("Delegate initializes with an unencrypted Ed25519 PKCS#8 key")
+    func testEd25519PKCS8Initialization() {
+        let delegate = FlexibleAuthDelegate(username: "test", password: nil,
+                                            privateKeyString: ed25519PKCS8,
+                                            privateKeyPassphrase: nil)
+        #expect(delegate.privateKey != nil)
+    }
+
+    @Test("Delegate decrypts an encrypted Ed25519 PKCS#8 key")
+    func testEd25519PKCS8EncryptedInitialization() {
+        let delegate = FlexibleAuthDelegate(username: "test", password: nil,
+                                            privateKeyString: ed25519PKCS8Encrypted,
+                                            privateKeyPassphrase: fixtureUnlock)
+        #expect(delegate.privateKey != nil)
+    }
+
+    @Test("Encrypted Ed25519 PKCS#8 decrypts to the exact original key")
+    func testEd25519PKCS8RecoversOriginalKey() throws {
+        let knownPub = Data(base64Encoded: "5TeA8DPnYQ97FJWdT+sUK+gnoTIJpocwlAUJzks7/Yc=")!
+        let der = try PEMDecryptor.decryptEncryptedPKCS8PEM(ed25519PKCS8Encrypted, passphrase: fixtureUnlock)
+        guard case .ed25519(let seed) = try PEMDecryptor.parsePKCS8PrivateKey(der) else {
+            Issue.record("Expected an Ed25519 key")
+            return
+        }
+        let pub = try Curve25519.Signing.PrivateKey(rawRepresentation: seed).publicKey.rawRepresentation
+        #expect(Data(pub) == knownPub)
+    }
+
     @Test("Delegate rejects an RSA key and records an initialization error")
     func testRSAKeyRejected() {
         let rsaKey = """


### PR DESCRIPTION
## Summary

Adds **Ed25519 in PKCS#8** (OID `1.3.101.112`, RFC 8410) — `openssl genpkey -algorithm ed25519` output, plain or encrypted, which previously failed with "unsupported format." Closes the first of the remaining key-support gaps noted in CLAUDE.md.

## Changes

- `PEMKey` gains an `.ed25519(seed:)` case.
- `parsePKCS8PrivateKey` handles the id-Ed25519 OID, unwrapping the nested `CurvePrivateKey` OCTET STRING (`04 20 || seed`) to the 32-byte seed.
- `FlexibleAuthDelegate` maps it to `NIOSSHPrivateKey(ed25519Key:)`. Encrypted PKCS#8 already flows through the existing PBES2/PBKDF2-SHA256/AES-256-CBC decryptor, so **encrypted Ed25519 works for free**.
- Key-format help text + CLAUDE.md support matrix updated.

## Testing

Builds clean (regular + build-for-testing). Verified with `RunCodeSnippet` against real `openssl` keys (the Swift Testing runner is still unstable on this beta toolchain), plus unit tests:

| Case | Result |
|---|---|
| Ed25519 PKCS#8, unencrypted | ✅ parses |
| Ed25519 PKCS#8, encrypted (AES-256-CBC + PBKDF2-SHA256) | ✅ parses |
| **Recovered pubkey == original** | ✅ byte-exact |
| EC / SEC1 / OpenSSH (regression) | ✅ unaffected |

## Remaining gaps (not in this PR)

Encrypted-OpenSSH AES-CBC/AEAD ciphers (only AES-CTR handled); broader PKCS#8 ciphers/KDFs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)