### PR TITLE
docs: restore Ed25519-PKCS#8 notes lost in the #52/#53 merge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,12 +35,12 @@ Supported private-key formats (all for Ed25519 / ECDSA only):
 | Format | Plain | Encrypted |
 |---|---|---|
 | OpenSSH (`openssh-key-v1`) | ✅ | ✅ bcrypt + aes128/192/256 ctr/cbc/gcm |
-| PKCS#8 (`BEGIN PRIVATE KEY`) | ✅ (EC only) | ✅ EC only, PBES2/PBKDF2-SHA256/AES-256-CBC |
+| PKCS#8 (`BEGIN PRIVATE KEY`) | ✅ (EC + Ed25519) | ✅ EC + Ed25519, PBES2/PBKDF2-SHA256/AES-256-CBC |
 | SEC1 (`BEGIN EC PRIVATE KEY`) | ✅ | — |
 
-Known gaps (not yet implemented): Ed25519 in PKCS#8 (OID 1.3.101.112); the
-`chacha20-poly1305@openssh.com` and `3des-cbc` OpenSSH ciphers (chacha20 is a
-non-standard construction absent from CryptoKit); broader PKCS#8 ciphers/KDFs.
+Known gaps (not yet implemented): the `chacha20-poly1305@openssh.com` and
+`3des-cbc` OpenSSH ciphers (chacha20 is a non-standard construction absent from
+CryptoKit); broader PKCS#8 ciphers/KDFs.
 
 ---
 


### PR DESCRIPTION
The `CLAUDE.md` conflict resolution when merging #53 after #52 took #53's side for the whole *Private key support* region, silently dropping #52's two edits:

- PKCS#8 support row reverted to **"EC only"** (should be **"EC + Ed25519"**).
- **"Ed25519 in PKCS#8"** reappeared in *Known gaps* even though #52 implemented it.

This restores both while keeping #53's correct OpenSSH `ctr/cbc/gcm` changes. The code itself merged cleanly — verified the merged `Development` builds (regular + build-for-testing) and that both Ed25519-PKCS#8 and OpenSSH AES-GCM keys still decrypt. Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)