### PR TITLE
refactor: migrate host-key validation callback to async/await

### DIFF
--- a/SSH TunnelBuilder/Classes/ConnectionStore.swift
+++ b/SSH TunnelBuilder/Classes/ConnectionStore.swift
@@ -72,6 +72,11 @@ class ConnectionStore {
     var errorAlert: ErrorAlert? = nil
     var hostKeyRequest: HostKeyRequest? = nil
 
+    /// The resume handler for an in-flight host-key prompt, if any. Tracked so a
+    /// superseding prompt can deny the previous one instead of leaking its
+    /// awaiting Task.
+    @ObservationIgnored private var pendingHostKeyDecision: ((Bool) -> Void)?
+
     @ObservationIgnored private var managers: [UUID: SSHManager] = [:]
 
     /// Credentials storage (Keychain in production, mock for tests)
@@ -203,6 +208,38 @@ class ConnectionStore {
         errorAlert = ErrorAlert(message: message)
     }
 
+    /// Presents the unknown-host prompt and suspends until the user answers.
+    /// On trust, records the key on the connection and persists it.
+    /// - Returns: `true` if the user trusts the host, `false` otherwise.
+    private func confirmHostKeyTrust(host: String, fingerprint: String,
+                                     keyData: Data, connection: Connection) async -> Bool {
+        // If a prior prompt is still awaiting an answer, deny it before replacing
+        // it so its awaiting Task can't leak.
+        pendingHostKeyDecision?(false)
+
+        let trusted = await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
+            // Resume at most once, whether the answer arrives from the UI or from
+            // a superseding prompt clearing this one.
+            var hasResumed = false
+            let decide: (Bool) -> Void = { [weak self] decision in
+                guard !hasResumed else { return }
+                hasResumed = true
+                self?.pendingHostKeyDecision = nil
+                continuation.resume(returning: decision)
+            }
+            pendingHostKeyDecision = decide
+            hostKeyRequest = HostKeyRequest(hostname: host, fingerprint: fingerprint,
+                                            keyData: keyData, completion: decide)
+        }
+
+        if trusted {
+            // Record the now-trusted key on the connection and persist to CloudKit.
+            connection.connectionInfo.knownHostKey = keyData.base64EncodedString()
+            saveConnection(connection, connectionToUpdate: connection)
+        }
+        return trusted
+    }
+
     private func manager(for connection: Connection) -> SSHManager {
         if let existing = managers[connection.id] { return existing }
         // Ensure SSHManager initialization uses the correct, restored name
@@ -216,20 +253,12 @@ class ConnectionStore {
     func connect(_ connection: Connection) {
         let mgr = manager(for: connection)
 
-        // Configure the host key validation callback
-        mgr.hostKeyValidationCallback = { [weak self] host, fingerprint, _, keyData, completion in
-            Task { @MainActor in
-                // We wrap the original completion to handle saving the key if trusted
-                self?.hostKeyRequest = HostKeyRequest(hostname: host, fingerprint: fingerprint, keyData: keyData) { trusted in
-                    if trusted {
-                        // Update the connection object with the new trusted key
-                        connection.connectionInfo.knownHostKey = keyData.base64EncodedString()
-                        // Persist this change to CloudKit immediately
-                        self?.saveConnection(connection, connectionToUpdate: connection)
-                    }
-                    completion(trusted)
-                }
-            }
+        // Configure the host key validation handler. It suspends until the user
+        // answers the prompt, then returns their trust decision.
+        mgr.hostKeyValidationHandler = { [weak self] host, fingerprint, _, keyData in
+            guard let self else { return false }
+            return await self.confirmHostKeyTrust(host: host, fingerprint: fingerprint,
+                                                  keyData: keyData, connection: connection)
         }
 
         // Configure the error callback to show alerts

--- a/SSH TunnelBuilder/Classes/SSHManager.swift
+++ b/SSH TunnelBuilder/Classes/SSHManager.swift
@@ -501,8 +501,8 @@ final class SSHManager: @unchecked Sendable {
     private var sessionReadyPromise: EventLoopPromise<Void>?
     private var sessionReadyCompleted = false
 
-    // Callback: (hostname, fingerprint, keyType, keyData, completion)
-    var hostKeyValidationCallback: (@Sendable (String, String, String, Data, @escaping @Sendable (Bool) -> Void) -> Void)?
+    // Async handler: (hostname, fingerprint, keyType, keyData) -> user's trust decision
+    var hostKeyValidationHandler: (@Sendable (String, String, String, Data) async -> Bool)?
 
     /// Callback invoked when an error occurs that should be shown to the user
     var errorCallback: (@Sendable (String) -> Void)?
@@ -675,18 +675,21 @@ final class SSHManager: @unchecked Sendable {
             return
         }
 
-        guard let callback = self.hostKeyValidationCallback else {
+        guard let handler = self.hostKeyValidationHandler else {
             promise.fail(SSHTunnelError.hostKeyValidationMissing)
             return
         }
 
         let keyType = keyData == nil ? "Unknown (Legacy Lib)" : "Unknown"
-        callback(host, fingerprint, keyType, keyData ?? Data()) { allowed in
-            if allowed {
-                promise.succeed(())
-            } else {
-                promise.fail(SSHTunnelError.hostKeyRejected)
-            }
+        let resolvedKeyData = keyData ?? Data()
+
+        // Bridge the async UI decision back onto the NIO promise. NIOSSH's
+        // validateHostKey is not async, so we keep its promise and fulfil it from
+        // the awaited result. EventLoopPromise is Sendable and hops to its own
+        // event loop when completed, so resolving it from this Task is safe.
+        Task {
+            let allowed = await handler(host, fingerprint, keyType, resolvedKeyData)
+            allowed ? promise.succeed(()) : promise.fail(SSHTunnelError.hostKeyRejected)
         }
     }
     


### PR DESCRIPTION
## Summary

Migrates `SSHManager`'s host-key validation from a nested-completion callback to async/await. The old `hostKeyValidationCallback` was a closure that handed back *another* closure (`@escaping (Bool) -> Void`) — an inverted control flow spread across three files. The check is fundamentally a *wait-for-the-user* operation, which `await` models directly.

## Changes

- **`SSHManager.swift`** — `hostKeyValidationCallback` → `hostKeyValidationHandler: (@Sendable (String, String, String, Data) async -> Bool)?`. `handleHostKeyValidation` bridges the awaited `Bool` back onto NIOSSH's non-async `EventLoopPromise` via a small `Task` (NIOSSH's `validateHostKey` can't be async, so we keep the promise and fulfil it from the result).
- **`ConnectionStore.swift`** — the handler assignment becomes a one-liner that awaits the new `confirmHostKeyTrust(...)`, which uses `withCheckedContinuation` to suspend until the user answers the SwiftUI prompt, then records/persists the trusted key sequentially.
- **`ContentView.swift` / `HostKeyRequest`** — unchanged. The continuation hides behind the struct's existing `completion: (Bool) -> Void`.

## Continuation-leak guard

A superseding prompt now denies the previous one (`pendingHostKeyDecision?(false)`) before installing itself, and resumption is idempotent (`hasResumed`) — so no leaked or double-resumed continuation if a second unknown-host prompt arrives while one is pending. (The old callback path had the latent hang; this closes it.)

## Verification

- Fast diagnostics: 0 issues in both changed files.
- Full `BuildProject`: succeeded, zero errors/warnings.
- No stale `hostKeyValidationCallback` references remain.
- ⚠️ Test suite **not run** — blocked by the Swift Testing runner crash on the current Xcode/macOS beta toolchain (documented in CLAUDE.md). Change is compile-validated, not behaviourally tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)