### PR TITLE
refactor: load Keychain secrets lazily (prep for optional auth-to-use)

### DIFF
--- a/SSH TunnelBuilder/Classes/ConnectionStore.swift
+++ b/SSH TunnelBuilder/Classes/ConnectionStore.swift
@@ -240,6 +240,18 @@ class ConnectionStore {
         return trusted
     }
 
+    /// Populates `connection`'s secrets from the Keychain if they aren't already
+    /// set in memory. A no-op for fields that already carry a value (e.g. typed
+    /// into the credentials sheet for this session).
+    private func hydrateCredentials(for connection: Connection) {
+        if connection.connectionInfo.password.isEmpty {
+            connection.connectionInfo.password = credentialsStore.loadPassword(for: connection.id) ?? ""
+        }
+        if connection.connectionInfo.privateKey.isEmpty {
+            connection.connectionInfo.privateKey = credentialsStore.loadPrivateKey(for: connection.id) ?? ""
+        }
+    }
+
     private func manager(for connection: Connection) -> SSHManager {
         if let existing = managers[connection.id] { return existing }
         // Ensure SSHManager initialization uses the correct, restored name
@@ -251,6 +263,13 @@ class ConnectionStore {
     /// Initiates an SSH connection for the given connection object
     /// - Parameter connection: The connection to establish
     func connect(_ connection: Connection) {
+        // Load stored secrets just before connecting. They're not kept in the
+        // in-memory model at rest, so this is the point where they're read back
+        // (and where a future "require authentication" prompt would appear).
+        // Values already present — e.g. just entered in the credentials sheet —
+        // are left untouched.
+        hydrateCredentials(for: connection)
+
         let mgr = manager(for: connection)
 
         // Configure the host key validation handler. It suspends until the user
@@ -401,7 +420,29 @@ class ConnectionStore {
     }
     
     func updateTempConnection(with connection: Connection) {
-        self.tempConnection = connection.copy() // Use a copy for editing
+        let copy = connection.copy() // Use a copy for editing
+        // Secrets aren't held in the in-memory model at rest (lazy loading), so
+        // pull them into the editable copy now. Otherwise saving an edit (even
+        // an unrelated change like the name) would persist empty secrets over
+        // the stored ones. This is also where a future auth prompt for editing
+        // would surface.
+        if copy.connectionInfo.password.isEmpty {
+            copy.connectionInfo.password = credentialsStore.loadPassword(for: connection.id) ?? ""
+        }
+        if copy.connectionInfo.privateKey.isEmpty {
+            copy.connectionInfo.privateKey = credentialsStore.loadPrivateKey(for: connection.id) ?? ""
+        }
+        self.tempConnection = copy
+    }
+
+    /// Whether a password is stored for this connection, without reading it.
+    func hasStoredPassword(_ connection: Connection) -> Bool {
+        credentialsStore.hasPassword(for: connection.id)
+    }
+
+    /// Whether a private key is stored for this connection, without reading it.
+    func hasStoredPrivateKey(_ connection: Connection) -> Bool {
+        credentialsStore.hasPrivateKey(for: connection.id)
     }
     
     func clearTempConnection() {
@@ -618,13 +659,17 @@ class ConnectionStore {
         let remotePort = portString(record, CloudKitKeys.remotePort)
 
         let knownHostKey = (record[CloudKitKeys.knownHostKey] as? String) ?? ""
-        
-        // Keychain operations are synchronous
-        let password = credentialsStore.loadPassword(for: uuid) ?? ""
-        let privateKey = credentialsStore.loadPrivateKey(for: uuid) ?? ""
-        // Note: privateKeyPassphrase is not persisted long-term
 
-        let connectionInfo = ConnectionInfo(name: name, serverAddress: serverAddress, portNumber: portNumber, username: username, password: password, privateKey: privateKey, privateKeyPassphrase: "", knownHostKey: knownHostKey)
+        // Secrets are NOT loaded into the in-memory model here. They're read
+        // lazily from the Keychain at the moment they're needed — at connect
+        // time (`hydrateCredentials`) and when editing (`updateTempConnection`).
+        // This keeps the whole connection list from pulling every secret on
+        // launch, and is the single choke point a future "require auth to use
+        // credentials" prompt can hook into. Existence (for display and the
+        // connect gate) is checked via `hasStoredPassword`/`hasStoredPrivateKey`
+        // without reading the secret value.
+        // Note: privateKeyPassphrase is not persisted long-term.
+        let connectionInfo = ConnectionInfo(name: name, serverAddress: serverAddress, portNumber: portNumber, username: username, password: "", privateKey: "", privateKeyPassphrase: "", knownHostKey: knownHostKey)
         let tunnelInfo = TunnelInfo(localPort: localPort, remoteServer: remoteServer, remotePort: remotePort)
 
         return Connection(id: uuid, recordID: record.recordID, connectionInfo: connectionInfo, tunnelInfo: tunnelInfo)

--- a/SSH TunnelBuilder/Classes/KeychainService.swift
+++ b/SSH TunnelBuilder/Classes/KeychainService.swift
@@ -9,6 +9,13 @@ protocol CredentialsStore {
     func loadPassword(for id: UUID) -> String?
     func loadPrivateKey(for id: UUID) -> String?
     func deleteCredentials(for id: UUID)
+
+    /// Whether a password is stored for `id`, checked *without* reading the
+    /// secret value. Lets the UI know credentials exist without holding them in
+    /// memory (and, once items are access-control protected, without prompting).
+    func hasPassword(for id: UUID) -> Bool
+    /// Whether a private key is stored for `id`. See `hasPassword(for:)`.
+    func hasPrivateKey(for id: UUID) -> Bool
 }
 
 // MARK: - Account Keys
@@ -51,7 +58,29 @@ final class KeychainService: CredentialsStore, Sendable {
         deleteItem(account: CredentialAccount.privateKey(for: id))
     }
 
+    func hasPassword(for id: UUID) -> Bool {
+        containsItem(account: CredentialAccount.password(for: id))
+    }
+
+    func hasPrivateKey(for id: UUID) -> Bool {
+        containsItem(account: CredentialAccount.privateKey(for: id))
+    }
+
     // MARK: - Low-level helpers
+
+    /// Existence check that queries for a match without requesting the item's
+    /// data. Reading attributes (not `kSecValueData`) never triggers an
+    /// authentication prompt, even for access-control-protected items.
+    private func containsItem(account: String) -> Bool {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecReturnData as String: false,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+        return SecItemCopyMatching(query as CFDictionary, nil) == errSecSuccess
+    }
 
     private func saveString(_ string: String, account: String) {
         guard let data = string.data(using: .utf8) else { return }
@@ -118,6 +147,14 @@ final class MockCredentialsStore: CredentialsStore {
     func deleteCredentials(for id: UUID) {
         storage.removeValue(forKey: CredentialAccount.password(for: id))
         storage.removeValue(forKey: CredentialAccount.privateKey(for: id))
+    }
+
+    func hasPassword(for id: UUID) -> Bool {
+        storage[CredentialAccount.password(for: id)]?.isEmpty == false
+    }
+
+    func hasPrivateKey(for id: UUID) -> Bool {
+        storage[CredentialAccount.privateKey(for: id)]?.isEmpty == false
     }
 }
 

--- a/SSH TunnelBuilder/GUI/CredentialsSheetView.swift
+++ b/SSH TunnelBuilder/GUI/CredentialsSheetView.swift
@@ -21,8 +21,11 @@ struct ConnectButtonView: View {
             if connection.isActive {
                 connectionStore.disconnect(connection)
             } else {
-                let hasPassword = !connection.connectionInfo.password.isEmpty
-                let hasKey = !connection.connectionInfo.privateKey.isEmpty
+                // Secrets aren't held in memory at rest, so ask the store
+                // whether credentials exist (checked without reading them)
+                // rather than inspecting the model's (empty) fields.
+                let hasPassword = connectionStore.hasStoredPassword(connection)
+                let hasKey = connectionStore.hasStoredPrivateKey(connection)
                 if !(hasPassword || hasKey) {
                     showCredentialsSheet = true
                     return

--- a/SSH TunnelBuilder/GUI/MainView.swift
+++ b/SSH TunnelBuilder/GUI/MainView.swift
@@ -259,20 +259,29 @@ struct MainView: View {
         )
     }
 
+    // Secrets aren't loaded into the model at rest, so in `.view` mode these
+    // bindings reflect Keychain *existence* (so the "<obfuscated>" indicator
+    // still appears) rather than the model's empty value. Create/edit modes
+    // use the real value as before (edit hydrates its temp copy).
     private var passwordBinding: Binding<String> {
-        formBinding(
-            createKeyPath: \.password,
-            editConnectionInfoKeyPath: \.password,
-            viewConnectionInfoKeyPath: \.password
-        )
+        if connectionStore.mode == .view {
+            return secretViewBinding(exists: selectedConnection.map { connectionStore.hasStoredPassword($0) } ?? false)
+        }
+        return formBinding(createKeyPath: \.password, editConnectionInfoKeyPath: \.password)
     }
 
     private var privateKeyBinding: Binding<String> {
-        formBinding(
-            createKeyPath: \.privateKey,
-            editConnectionInfoKeyPath: \.privateKey,
-            viewConnectionInfoKeyPath: \.privateKey
-        )
+        if connectionStore.mode == .view {
+            return secretViewBinding(exists: selectedConnection.map { connectionStore.hasStoredPrivateKey($0) } ?? false)
+        }
+        return formBinding(createKeyPath: \.privateKey, editConnectionInfoKeyPath: \.privateKey)
+    }
+
+    /// A read-only binding whose value is a non-empty sentinel when a secret
+    /// exists. `EditableFieldView` shows "<obfuscated>" for any non-empty secure
+    /// value, so this drives the indicator without loading the secret itself.
+    private func secretViewBinding(exists: Bool) -> Binding<String> {
+        .constant(exists ? "********" : "")
     }
 
     private var localPortBinding: Binding<String> {

--- a/SSH TunnelBuilderTests/SSH_TunnelBuilderTests.swift
+++ b/SSH TunnelBuilderTests/SSH_TunnelBuilderTests.swift
@@ -228,7 +228,7 @@ struct ConnectionStoreLocalTests {
         return Connection(id: id, connectionInfo: info, tunnelInfo: tunnel)
     }
 
-    @Test("Secrets are saved to Keychain and retrieved correctly via recordToConnection")
+    @Test("Secrets are saved to Keychain and exposed via existence, not eagerly loaded")
     @MainActor func testSecretHandlingInRecordMapping() throws {
         let store = ConnectionStore(mode: .view, connections: [])
         let id = UUID()
@@ -245,10 +245,13 @@ struct ConnectionStoreLocalTests {
         #expect((record["password"] as? String ?? "") == "")
         #expect((record["privateKey"] as? String ?? "") == "")
 
-        // Secrets must be recoverable via the store's credentials layer
+        // Secrets are loaded lazily, so the mapped model carries empty fields...
         let retrieved = try #require(store.recordToConnection(record: record))
-        #expect(retrieved.connectionInfo.password == "test_password")
-        #expect(retrieved.connectionInfo.privateKey == "test_key_pem")
+        #expect(retrieved.connectionInfo.password == "")
+        #expect(retrieved.connectionInfo.privateKey == "")
+        // ...but their presence is still detectable without reading the values.
+        #expect(store.hasStoredPassword(retrieved))
+        #expect(store.hasStoredPrivateKey(retrieved))
     }
 
     @Test("Updating temporary connection uses a deep copy")
@@ -675,9 +678,11 @@ struct ConnectionStoreMappingTests {
         #expect(result.connectionInfo.name == "Test Server")
         #expect(result.connectionInfo.serverAddress == "server.example.com")
         #expect(result.connectionInfo.username == "testuser")
-        // Secrets recovered from the mock credentials store
-        #expect(result.connectionInfo.password == "testpassword")
-        #expect(result.connectionInfo.privateKey == "testkey")
+        // Secrets are loaded lazily: not in the mapped model, but detectable.
+        #expect(result.connectionInfo.password == "")
+        #expect(result.connectionInfo.privateKey == "")
+        #expect(store.hasStoredPassword(result))
+        #expect(store.hasStoredPrivateKey(result))
         // Port fields survive the String -> Int64 -> String round-trip
         #expect(result.connectionInfo.portNumber == "2222")
         #expect(result.tunnelInfo.localPort == "9000")


### PR DESCRIPTION
## Summary
**PR 1 of 2** toward the optional "require Touch ID / password to use saved credentials" feature. This PR is a behavior-preserving refactor that stops loading secrets into memory eagerly; the toggle itself lands in a follow-up PR on top of this.

Today, `ConnectionStore.recordToConnection(...)` reads each connection's password + private key from the Keychain into the in-memory model — for the **entire list at launch**. That's both more secret-in-memory than necessary and, crucially, incompatible with access-control-protected items (it would trigger an auth prompt for every connection at startup). This defers secret reads to the point of use.

## Changes
- **`CredentialsStore`**: new `hasPassword(for:)` / `hasPrivateKey(for:)`. `KeychainService` implements them with an **attributes-only** query (no `kSecValueData`), which never prompts for auth — even once items become access-control protected.
- **`ConnectionStore`**:
  - `recordToConnection` no longer loads secrets (model holds `""` at rest).
  - `connect()` **hydrates** secrets from the Keychain right before connecting (no-op if already entered in the credentials sheet).
  - `updateTempConnection()` hydrates the editable copy, so saving an edit still round-trips the stored secret — **no accidental erase when renaming**.
  - new `hasStoredPassword` / `hasStoredPrivateKey` for the UI.
- **`CredentialsSheetView`**: the Connect gate asks the store whether credentials exist instead of reading the (now-empty) model fields.
- **`MainView`**: the password / private-key rows show `<obfuscated>` in view mode based on *existence*, not the in-memory value.
- **Tests**: the two `recordToConnection` mapping tests now assert the lazy contract (empty in model, detectable via existence).

## Why split from the feature
Keeps this mechanical, behavior-preserving change reviewable on its own; the user-facing security toggle (Keychain access control + auth prompt + re-key on toggle) builds on these seams in PR 2.

## Test plan
- `BuildProject` (regular + `buildForTesting`): succeeds, 0 errors.
- Credential-layer existence semantics verified via `RunCodeSnippet` (save/load/exists/scoping/empty/delete all correct).
- Full XCTest/Swift Testing suite not run — known macOS 27 Swift Testing runner crash (see CLAUDE.md). The two affected unit tests were updated to the new contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)