### PR TITLE
feat: optional Touch ID / password protection for saved credentials

### DIFF
--- a/SSH TunnelBuilder/Classes/ConnectionStore.swift
+++ b/SSH TunnelBuilder/Classes/ConnectionStore.swift
@@ -264,10 +264,10 @@ class ConnectionStore {
     /// - Parameter connection: The connection to establish
     func connect(_ connection: Connection) {
         // Load stored secrets just before connecting. They're not kept in the
-        // in-memory model at rest, so this is the point where they're read back
-        // (and where a future "require authentication" prompt would appear).
-        // Values already present — e.g. just entered in the credentials sheet —
-        // are left untouched.
+        // in-memory model at rest, so this is the point where they're read back —
+        // and, when "require authentication" is on, where the OS prompts for
+        // Touch ID / password. Values already present (e.g. just entered in the
+        // credentials sheet) are left untouched.
         hydrateCredentials(for: connection)
 
         let mgr = manager(for: connection)
@@ -309,8 +309,29 @@ class ConnectionStore {
         if let mgr = managers[connection.id] {
             Task {
                 await mgr.disconnect()
+                // When credentials are protected, drop the hydrated secrets from
+                // memory after use so the next connect re-authenticates. (When
+                // protection is off we leave them, preserving the prior behaviour
+                // where session-entered credentials survive a reconnect.)
+                if self.isCredentialProtectionEnabled {
+                    connection.connectionInfo.password = ""
+                    connection.connectionInfo.privateKey = ""
+                }
             }
         }
+    }
+
+    /// Whether the user has opted in to requiring authentication to use saved
+    /// credentials. Mirrors the Settings toggle.
+    var isCredentialProtectionEnabled: Bool {
+        UserDefaults.standard.bool(forKey: KeychainService.protectionEnabledKey)
+    }
+
+    /// Re-keys all stored credentials to match the new protection preference.
+    /// The preference itself is written by the Settings toggle (`@AppStorage`)
+    /// before this runs; here we just bring existing Keychain items in line.
+    func reprotectStoredCredentials(enabled: Bool) {
+        credentialsStore.setCredentialProtection(enabled: enabled, for: connections.map(\.id))
     }
     
     // MARK: - CloudKit Helpers (Synchronized via Task/Async/Await)

--- a/SSH TunnelBuilder/Classes/KeychainService.swift
+++ b/SSH TunnelBuilder/Classes/KeychainService.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Security
+import LocalAuthentication
 
 // MARK: - Protocol
 
@@ -16,6 +17,16 @@ protocol CredentialsStore {
     func hasPassword(for id: UUID) -> Bool
     /// Whether a private key is stored for `id`. See `hasPassword(for:)`.
     func hasPrivateKey(for id: UUID) -> Bool
+
+    /// Re-saves the stored credentials for the given connection ids so they
+    /// match the current protection preference (access-control on/off). Called
+    /// when the user toggles the "require authentication" setting. Stores that
+    /// don't support OS-level protection (e.g. the mock) can ignore this.
+    func setCredentialProtection(enabled: Bool, for ids: [UUID])
+}
+
+extension CredentialsStore {
+    func setCredentialProtection(enabled: Bool, for ids: [UUID]) {}
 }
 
 // MARK: - Account Keys
@@ -35,6 +46,21 @@ final class KeychainService: CredentialsStore, Sendable {
 
     private let service = "SSH Tunnel Manager"
 
+    /// `UserDefaults` key backing the "require Touch ID / password to use saved
+    /// credentials" setting. Shared with the `@AppStorage` binding in Settings.
+    static let protectionEnabledKey = "RequireAuthForStoredCredentials"
+
+    /// Whether stored credentials should be protected by user-presence
+    /// (Touch ID / password). Read fresh on each save so a toggle takes effect
+    /// immediately for subsequently re-keyed items.
+    private var isProtectionEnabled: Bool {
+        UserDefaults.standard.bool(forKey: Self.protectionEnabledKey)
+    }
+
+    /// Default prompt shown when the OS asks the user to authenticate before a
+    /// protected credential is read.
+    private static let useReason = "Authenticate to use your saved SSH credentials."
+
     // MARK: - Public API
 
     func savePassword(_ password: String, for id: UUID) {
@@ -46,11 +72,11 @@ final class KeychainService: CredentialsStore, Sendable {
     }
 
     func loadPassword(for id: UUID) -> String? {
-        loadString(account: CredentialAccount.password(for: id))
+        loadString(account: CredentialAccount.password(for: id), context: makeAuthContext(reason: Self.useReason))
     }
 
     func loadPrivateKey(for id: UUID) -> String? {
-        loadString(account: CredentialAccount.privateKey(for: id))
+        loadString(account: CredentialAccount.privateKey(for: id), context: makeAuthContext(reason: Self.useReason))
     }
 
     func deleteCredentials(for id: UUID) {
@@ -64,6 +90,29 @@ final class KeychainService: CredentialsStore, Sendable {
 
     func hasPrivateKey(for id: UUID) -> Bool {
         containsItem(account: CredentialAccount.privateKey(for: id))
+    }
+
+    /// Re-saves every stored secret so its Keychain protection matches the
+    /// current `isProtectionEnabled` preference. A single `LAContext` is reused
+    /// across the batch so disabling protection (which must *read* the currently
+    /// protected items) prompts the user only once.
+    func setCredentialProtection(enabled: Bool, for ids: [UUID]) {
+        let reason = enabled
+            ? "Authenticate to protect your saved SSH credentials with Touch ID or your password."
+            : "Authenticate to remove Touch ID / password protection from your saved SSH credentials."
+        // One reusable context so the whole re-key pass authenticates at most once.
+        let context = makeAuthContext(reason: reason, reuseDuration: 30)
+
+        for id in ids {
+            let pwAccount = CredentialAccount.password(for: id)
+            if let password = loadString(account: pwAccount, context: context) {
+                saveString(password, account: pwAccount)
+            }
+            let keyAccount = CredentialAccount.privateKey(for: id)
+            if let key = loadString(account: keyAccount, context: context) {
+                saveString(key, account: keyAccount)
+            }
+        }
     }
 
     // MARK: - Low-level helpers
@@ -87,27 +136,68 @@ final class KeychainService: CredentialsStore, Sendable {
         // Delete existing item first to avoid duplicates
         deleteItem(account: account)
 
-        let query: [String: Any] = [
+        var query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
             kSecAttrAccount as String: account,
-            kSecValueData as String: data,
-            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock
+            kSecValueData as String: data
         ]
+        // When protection is enabled, gate reads behind user presence
+        // (Touch ID / password). `kSecAttrAccessControl` and `kSecAttrAccessible`
+        // are mutually exclusive, so set exactly one.
+        if isProtectionEnabled, let accessControl = makeUserPresenceAccessControl() {
+            query[kSecAttrAccessControl as String] = accessControl
+        } else {
+            query[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
+        }
         let status = SecItemAdd(query as CFDictionary, nil)
         if status != errSecSuccess {
             Logger.error("Failed to save item for account '\(account)'. OSStatus: \(status)", log: Logger.keychain)
         }
     }
 
-    private func loadString(account: String) -> String? {
-        let query: [String: Any] = [
+    /// Builds a user-presence access-control object: the item can only be read
+    /// after the user authenticates with Touch ID or their login password
+    /// (`.userPresence`), and never leaves this device.
+    private func makeUserPresenceAccessControl() -> SecAccessControl? {
+        var error: Unmanaged<CFError>?
+        let accessControl = SecAccessControlCreateWithFlags(
+            nil,
+            kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
+            .userPresence,
+            &error
+        )
+        if let error = error?.takeRetainedValue() {
+            Logger.error("Failed to create Keychain access control: \(error)", log: Logger.keychain)
+            return nil
+        }
+        return accessControl
+    }
+
+    /// Builds an `LAContext` carrying the prompt text shown when the OS asks the
+    /// user to authenticate. Passed to the Keychain via `kSecUseAuthenticationContext`
+    /// (the supported replacement for the deprecated `kSecUseOperationPrompt`).
+    /// A non-zero `reuseDuration` lets several reads share one authentication.
+    private func makeAuthContext(reason: String, reuseDuration: TimeInterval = 0) -> LAContext {
+        let context = LAContext()
+        context.localizedReason = reason
+        context.touchIDAuthenticationAllowableReuseDuration = reuseDuration
+        return context
+    }
+
+    /// Reads a stored string. For access-control-protected items the OS presents
+    /// an authentication prompt (using `context.localizedReason`); a shared
+    /// `context` lets a batch authenticate once. Unprotected items never prompt.
+    private func loadString(account: String, context: LAContext? = nil) -> String? {
+        var query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
             kSecAttrAccount as String: account,
             kSecReturnData as String: true,
             kSecMatchLimit as String: kSecMatchLimitOne
         ]
+        if let context { query[kSecUseAuthenticationContext as String] = context }
+
         var item: CFTypeRef?
         let status = SecItemCopyMatching(query as CFDictionary, &item)
         guard status == errSecSuccess, let data = item as? Data else { return nil }

--- a/SSH TunnelBuilder/GUI/SettingsView.swift
+++ b/SSH TunnelBuilder/GUI/SettingsView.swift
@@ -1,10 +1,11 @@
 import SwiftUI
 
-/// App preferences (opened with ⌘,). Currently hosts the opt-in Spotlight
-/// indexing control.
+/// App preferences (opened with ⌘,). Hosts the opt-in Spotlight indexing
+/// control and the optional Touch ID / password protection for credentials.
 struct SettingsView: View {
     @Environment(ConnectionStore.self) private var connectionStore
     @AppStorage(SpotlightIndexer.enabledDefaultsKey) private var spotlightEnabled = false
+    @AppStorage(KeychainService.protectionEnabledKey) private var requireAuthForCredentials = false
 
     var body: some View {
         Form {
@@ -17,6 +18,16 @@ struct SettingsView: View {
             } header: {
                 Text("Spotlight")
             }
+
+            Section {
+                Toggle("Require Touch ID or password to use saved credentials", isOn: $requireAuthForCredentials)
+                Text("When enabled, your saved passwords and private keys are stored so that connecting (or editing a connection) requires Touch ID or your login password. This adds a layer of protection if someone gains access to your unlocked Mac, at the cost of an authentication prompt each time you connect.")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            } header: {
+                Text("Security")
+            }
         }
         .formStyle(.grouped)
         .frame(width: 460)
@@ -28,6 +39,13 @@ struct SettingsView: View {
             } else {
                 SpotlightIndexer.deindexAll()
             }
+        }
+        .onChange(of: requireAuthForCredentials) { _, isOn in
+            // The preference (read by KeychainService when saving) is already
+            // updated by @AppStorage; re-key the existing stored credentials so
+            // the new protection applies to them too. Disabling prompts once to
+            // read the currently protected items.
+            connectionStore.reprotectStoredCredentials(enabled: isOn)
         }
     }
 }


### PR DESCRIPTION
## Summary
**PR 2 of 2** for the customer-facing security knob. Adds an **opt-in** Settings toggle — *"Require Touch ID or password to use saved credentials"* (default **off**). When enabled, stored passwords and private keys are protected with a user-presence access-control flag, so reading them (at connect, or when editing a connection) requires Touch ID or the login password.

Built on the lazy-loading seams from #59, so authentication surfaces only when a secret is actually needed — never as a launch-time prompt storm.

## Changes
- **`KeychainService`**
  - `protectionEnabledKey` preference (shared with the Settings `@AppStorage`).
  - `saveString` attaches `SecAccessControlCreateWithFlags(.userPresence, kSecAttrAccessibleWhenUnlockedThisDeviceOnly)` when enabled; otherwise the prior `kSecAttrAccessibleAfterFirstUnlock`.
  - `loadString` supplies an `LAContext` (`kSecUseAuthenticationContext` + `localizedReason`) — the supported replacement for the deprecated `kSecUseOperationPrompt` — so the OS shows a clear prompt.
  - `setCredentialProtection(enabled:for:)` re-keys existing items to match the new preference, reusing one `LAContext` so **disabling prompts only once**.
- **`ConnectionStore`**
  - `reprotectStoredCredentials(enabled:)` drives the re-key from Settings.
  - On disconnect, clears hydrated secrets from memory **when protection is on** (so each reconnect re-authenticates). Unprotected behaviour is unchanged.
- **`SettingsView`**: new "Security" section with the toggle, explanation, and re-key on change.

## Behaviour
- **Off (default):** identical to today.
- **Turn on:** existing credentials are re-saved as protected (no prompt — reading currently-unprotected items needs no auth). Next connect/edit prompts for Touch ID / password.
- **Turn off:** prompts once to read the protected items, then re-saves them unprotected.

## Security hotspot
This gives the `KeychainService` accessibility hotspot a defensible answer: users who want per-use authentication can now require it. The default still uses `AfterFirstUnlock`, so the hotspot remains a "review → mark safe" item rather than being removed.

## Test plan
- `BuildProject` (regular + `buildForTesting`): succeeds, **0 errors, 0 warnings** (verified per-file diagnostics; the `kSecUseOperationPrompt` deprecation was resolved).
- Access-control configuration validated on macOS 27 via `RunCodeSnippet` (ACL creates cleanly; `LAContext.localizedReason` settable; `deviceOwnerAuthentication` available).
- ⚠️ **Needs an interactive on-device smoke test** — the biometric prompt itself can't be exercised in CI / `RunCodeSnippet` (a protected read blocks on the system auth sheet). Suggested manual checks: toggle on → connect prompts; toggle off → single prompt then connects without auth; edit a connection while protected → prompts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)