### PR TITLE
fix: reflect created/edited connection name in sidebar without restart

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -252,6 +252,39 @@ compile-validated but not behaviourally tested on this toolchain.
 
 ## Known Issues
 
+### Open bugs (to fix)
+
+- [x] **New/edited connection name not shown in the sidebar until app restart (2026-06-16) — FIXED**
+  - **Symptom:** After creating or renaming a connection, the sidebar row's
+    **name didn't update** (showed blank/stale) until the app was relaunched and
+    re-fetched from CloudKit. Not data loss — the record always persisted.
+  - **Root cause:** `Connection` is `@Observable` but `Equatable`/`Hashable` by
+    `id` only (`Connection.swift:88-95`). `upsertConnection` did
+    `connections[index] = newInstance` — a *different* object with the same `id`
+    — so SwiftUI's `List`/`ForEach` treated it as unchanged and never swapped the
+    instance into `ConnectionRow` (or `selectedConnection`).
+  - **Fix (`ConnectionStore.swift`):** `upsertConnection` now **mutates the
+    existing instance in place** (`existing.connectionInfo = …`/`tunnelInfo = …`)
+    so the change is observed; this also preserves live `state`/byte counters that
+    a replacement would have reset. Additionally `createConnectionAsync` now
+    upserts straight from the `save()` echo record instead of issuing a second
+    `record(for:)` fetch (removes a round-trip and a read-back race that could
+    surface a blank name on create). Verified live: rename updated the sidebar
+    immediately, no relaunch.
+
+- [ ] **Detail pane (view mode) renders blank for a connection that has data (2026-06-16)**
+  - **Symptom:** Selecting a connection sometimes shows the `MainView` detail with
+    a blank name/status and empty fields, even though the data exists (the **Edit**
+    form for the same connection shows the real values, and the sidebar shows the
+    name). Resolves on reselect/relaunch in some cases.
+  - **Pre-existing / separate** from the sidebar fix above — reproduced on a clean
+    checkout with the fix stashed. **Not data loss.**
+  - **Likely area:** `MainView`'s view-mode bindings read
+    `selectedConnection?.connectionInfo[keyPath:]` via `.constant(...)`
+    (`MainView.swift:214-224`); investigate whether `body` re-evaluates / re-reads
+    the selected `@Observable` instance's `connectionInfo` when selection changes
+    (especially right after an edit, where `selectedConnection = tempConnection`).
+
 ### Test suite cannot run reliably on the macOS 26/27 beta toolchain (2026-06-15)
 
 **Symptom:** Running the test bundle crashes the test host in Swift Testing's

--- a/SSH TunnelBuilder/Classes/ConnectionStore.swift
+++ b/SSH TunnelBuilder/Classes/ConnectionStore.swift
@@ -485,8 +485,17 @@ class ConnectionStore {
     /// Inserts the connection, or replaces the existing entry with the same id.
     /// Keeps the in-memory list free of duplicates when re-fetching after a save.
     private func upsertConnection(_ connection: Connection) {
-        if let index = self.connections.firstIndex(where: { $0.id == connection.id }) {
-            self.connections[index] = connection
+        if let existing = self.connections.first(where: { $0.id == connection.id }) {
+            // Mutate the existing @Observable instance in place rather than
+            // swapping in a new one. `Connection` is Equatable/Hashable by `id`
+            // only, so SwiftUI's List/ForEach treats a replacement instance as
+            // unchanged and never refreshes the row or `selectedConnection` — the
+            // edited name wouldn't appear until a relaunch rebuilt the list.
+            // Updating the observed properties of the same instance propagates to
+            // the UI immediately, and preserves live runtime state (connection
+            // state / byte counters) that a fetched record would otherwise reset.
+            existing.connectionInfo = connection.connectionInfo
+            existing.tunnelInfo = connection.tunnelInfo
         } else {
             self.connections.append(connection)
         }
@@ -533,8 +542,15 @@ class ConnectionStore {
         record[CloudKitKeys.uuid] = connection.id.uuidString
 
         do {
+            // Upsert straight from the record CloudKit echoes back from save(),
+            // rather than issuing a second record(for:) fetch. The extra fetch
+            // adds a round-trip and can race — the just-saved record sometimes
+            // reads back before all fields propagate, which surfaced as a new
+            // connection appearing in the sidebar with a blank name until relaunch.
             let savedRecord = try await database.save(record)
-            await self.fetchConnectionAsync(withId: savedRecord.recordID)
+            if let saved = self.recordToConnection(record: savedRecord) {
+                self.upsertConnection(saved)
+            }
         } catch {
             Logger.error("Failed to save connection: \(self.cloudKitErrorDescription(error))", log: Logger.cloudKit)
             self.errorAlert = ErrorAlert(message: "Failed to save connection: \(error.localizedDescription)")


### PR DESCRIPTION
## Summary
The sidebar (NavigationView) row — and the detail pane / selection — did not update when a connection was **created** or **renamed**. The new name only appeared after relaunching the app (which rebuilds the list from a fresh CloudKit fetch).

## Root cause
`Connection` is `@Observable` but conforms to `Equatable`/`Hashable` by **`id` only** (`Connection.swift`). `upsertConnection` did `connections[index] = newInstance` — a *different* object with the same `id` — so SwiftUI's `List`/`ForEach` treated the element as unchanged and never swapped the new instance into `ConnectionRow` (or `selectedConnection`).

## Changes (`ConnectionStore.swift`)
- **`upsertConnection`** now mutates the **existing instance in place** (`connectionInfo` / `tunnelInfo`) instead of replacing the array element. The change is observed and the row updates immediately. Bonus: it no longer resets live `state` / byte counters that a fetched record would have clobbered on refresh.
- **`createConnectionAsync`** now upserts straight from the record `save()` echoes back, instead of issuing a second `record(for:)` fetch — removing a round-trip and a read-back race that could surface a blank name on create.

## Verification
Manually verified live on macOS: creating and renaming a connection now updates the sidebar **immediately, with no relaunch**. Project builds clean.

## Notes
- `CLAUDE.md` updated: marks this bug fixed and logs a **separate, pre-existing** issue (view-mode detail pane occasionally renders blank for a connection that has data — confirmed to reproduce without this change).
- The automated test suite remains blocked by the known Swift Testing runner crash on the current Xcode/macOS beta toolchain (see `CLAUDE.md`), so this is compile- + manually-verified, not covered by a new unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)