### PR TITLE
fix: pin host keys via real serialization (was no-op stub)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -254,28 +254,29 @@ compile-validated but not behaviourally tested on this toolchain.
 
 ### Open bugs (to fix)
 
-- [ ] **Host-key trust-on-first-use does not actually pin — re-prompts every connect (2026-06-16)**
-  - **Symptom:** Connecting to a host shows the "Unknown Host" prompt (good), but
-    after trusting it, **every subsequent connect re-prompts** — the trusted key is
-    never remembered. Verified live against `127.0.0.1:22`: trusted, disconnected,
-    reconnected → prompted again. The prompt's fingerprint always reads
+- [x] **Host-key trust-on-first-use does not actually pin — re-prompts every connect (2026-06-16) — FIXED**
+  - **Symptom:** Connecting to a host showed the "Unknown Host" prompt (good), but
+    after trusting it, **every subsequent connect re-prompted** — the trusted key
+    was never remembered. Verified live against `127.0.0.1:22`: trusted, disconnected,
+    reconnected → prompted again. The prompt's fingerprint always read
     `SHA256:UNAVAILABLE`.
-  - **Root cause:** `SSHManager.serialize(key:)` returns `nil` (NIOSSH exposes no
-    public host-key serialization API — `SSHManager.swift:224`). So in
-    `handleHostKeyValidation` the key bytes are empty: the fingerprint falls back to
-    the **constant** `"SHA256:UNAVAILABLE"` (not host-specific), and on trust the
-    stored value is `base64(Data())` = `""`. On reconnect `knownHostKey.isEmpty` is
-    true (`SSHManager.swift:191`), so the match block is skipped and the handler is
-    invoked again. Confirmed the CloudKit `knownHostKey` field stays empty.
-  - **Security impact:** because nothing is ever pinned, the host-key **mismatch /
-    MITM-detection** path (`SSHManager.swift:202`) can never trigger. The feature
-    currently delivers a confirmation prompt but **not** real pinning.
-  - **Fix direction:** needs real host-key bytes. Investigate a NIOSSH API to obtain
-    the public-key wire bytes (or upstream contribution); failing that, the prompt
-    should at least store *something* stable+unique per host so re-prompts stop —
-    but a constant placeholder can't provide the security guarantee. Note the doc
-    elsewhere already calls the serialization a known stub; this entry records the
-    user-facing functional gap.
+  - **Root cause:** `SSHManager.serialize(key:)` returned `nil` (believed NIOSSH
+    exposed no public host-key serialization API). So in `handleHostKeyValidation`
+    the key bytes were empty: the fingerprint fell back to the **constant**
+    `"SHA256:UNAVAILABLE"` (not host-specific), and on trust the stored value was
+    `base64(Data())` = `""`. On reconnect `knownHostKey.isEmpty` was true, the match
+    block was skipped, and the handler was invoked again.
+  - **Fix (`SSHManager.swift`):** NIOSSH *does* expose the canonical OpenSSH
+    public-key string via `String(openSSHPublicKey:)`. `serialize(key:)` now parses
+    its `"<algorithm-id> <base64-wire-bytes>"` form and returns the decoded wire-format
+    blob — the same bytes OpenSSH hashes for its fingerprint, stable and host-unique.
+    The fingerprint is now OpenSSH-style (SHA256, base64 **without** padding) so it
+    matches `ssh-keygen -l` / `ssh-keyscan`.
+  - **Verified live:** prompt now shows a real fingerprint
+    (`SHA256:wZGdCznz9+/IDVQD+QDJmYrtlOvs+qL8Mt8KX/rbVXs`) matching `ssh-keyscan`
+    exactly; trusting pins a real 68-char key blob to CloudKit; reconnect no longer
+    prompts. The **mismatch / MITM-detection** path now has a real pinned value to
+    compare against.
 
 - [x] **New/edited connection name not shown in the sidebar until app restart (2026-06-16) — FIXED**
   - **Symptom:** After creating or renaming a connection, the sidebar row's

--- a/SSH TunnelBuilder/Classes/SSHManager.swift
+++ b/SSH TunnelBuilder/Classes/SSHManager.swift
@@ -181,8 +181,11 @@ final class SSHManager: @unchecked Sendable {
         let keyData = serialize(key: key)
         let fingerprint: String
         if let keyData = keyData {
+            // OpenSSH-style fingerprint: SHA256 of the wire-format key blob,
+            // base64 without padding (matches `ssh-keygen -l` output).
             let digest = SHA256.hash(data: keyData)
-            fingerprint = "SHA256:" + Data(digest).base64EncodedString()
+            let base64 = Data(digest).base64EncodedString().replacingOccurrences(of: "=", with: "")
+            fingerprint = "SHA256:" + base64
         } else {
             // Fallback: we cannot serialize the key with this NIOSSH version; present a legacy marker.
             fingerprint = "SHA256:UNAVAILABLE"
@@ -221,12 +224,18 @@ final class SSHManager: @unchecked Sendable {
         }
     }
 
-    private func serialize(key _: NIOSSHPublicKey) -> Data? {
-        // NIOSSH does not currently expose a public API to serialize host keys to raw bytes.
-        // Returning nil causes handleHostKeyValidation to use fingerprint-based verification,
-        // which compares the SHA256 fingerprint string stored in knownHostKey.
-        // If NIOSSH adds serialization support in the future, implement it here for raw key matching.
-        return nil
+    private func serialize(key: NIOSSHPublicKey) -> Data? {
+        // NIOSSH exposes the canonical OpenSSH public-key string
+        // ("<algorithm-id> <base64-wire-bytes>") via `String(openSSHPublicKey:)`.
+        // The base64 component decodes to the SSH wire-format key blob — the same
+        // bytes OpenSSH hashes for its SHA256 fingerprint, and a stable, host-unique
+        // value we can pin for trust-on-first-use and compare on later connections.
+        let openSSHString = String(openSSHPublicKey: key)
+        let components = openSSHString.split(separator: " ", maxSplits: 2, omittingEmptySubsequences: true)
+        guard components.count >= 2, let blob = Data(base64Encoded: String(components[1])) else {
+            return nil
+        }
+        return blob
     }
 
     // MARK: - Local Listener / Forwarding


### PR DESCRIPTION
## Problem

Host-key trust-on-first-use never actually pinned. `SSHManager.serialize(key:)` returned `nil` (we believed NIOSSH exposed no host-key serialization API), so:

- the prompt's fingerprint fell back to the **constant** `SHA256:UNAVAILABLE` (not host-specific),
- on trust the stored `knownHostKey` was `base64(Data())` = `""`,
- on reconnect `knownHostKey.isEmpty` was true → the match block was skipped → **re-prompt on every connect**,
- and the host-key **mismatch / MITM-detection** path could never trigger, since nothing was ever pinned.

## Fix

NIOSSH *does* expose the canonical OpenSSH public-key string via `String(openSSHPublicKey:)`. `serialize(key:)` now parses its `"<algorithm-id> <base64-wire-bytes>"` form and returns the decoded SSH wire-format blob — the same bytes OpenSSH hashes for its fingerprint, stable and host-unique.

The fingerprint is now OpenSSH-style (SHA256, base64 **without** padding), so it matches `ssh-keygen -l` / `ssh-keyscan`.

## Verification (live, against `127.0.0.1:22`)

- Prompt shows a **real fingerprint** matching `ssh-keyscan` exactly.
- Trusting pins a real 68-char key blob to CloudKit (was empty before).
- Reconnect **no longer prompts** — the pinned key is matched.
- The mismatch/MITM path now has a real pinned value to compare against.

Build is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)