### PR TITLE
refactor: drop duplicate connecting spinner from DataCounterView

### DIFF
--- a/SSH TunnelBuilder/GUI/DataCounterView.swift
+++ b/SSH TunnelBuilder/GUI/DataCounterView.swift
@@ -19,11 +19,8 @@ struct DataCounterView: View {
                     Text("Data Received: \(connection.bytesReceived.formatted(.byteCount(style: .file)))")
                 }
                 Spacer()
-                VStack {
-                    if connection.isConnecting {
-                        ProgressView()
-                    }
-                }
+                // The connecting spinner lives in ConnectionIndicatorView (the
+                // status row), so it is intentionally not duplicated here.
             }
         }
     }


### PR DESCRIPTION
## Problem

Two `ProgressView` spinners rendered during a connection's `.connecting` state:
- `ConnectionIndicatorView` — the status row, where the spinner replaces the status dot alongside the "Connecting..." label (meaningful).
- `DataCounterView` — a second, unlabelled spinner next to the byte counters (redundant).

This is the cosmetic half of the "two spinning wheels" report (the functional half — the connection getting *stuck* in `.connecting` — was fixed in #65).

## Fix

Remove the spinner from `DataCounterView`; keep the contextual one in `ConnectionIndicatorView`. The counter layout is unchanged — the `Spacer()` is preserved so the counters stay left-aligned exactly as before.

Build is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)