### PR TITLE
Add menu bar traffic indicator

### DIFF
--- a/SSH TunnelBuilder/GUI/MenuBarTrafficView.swift
+++ b/SSH TunnelBuilder/GUI/MenuBarTrafficView.swift
@@ -1,0 +1,148 @@
+//
+//  MenuBarTrafficView.swift
+//  SSH TunnelBuilder
+//
+//  Menu bar traffic indicator: two dots in the system menu bar — a TX dot that
+//  blinks green while data is sent and an RX dot that blinks red while data is
+//  received. The item is only present while at least one tunnel is connected.
+//
+
+import SwiftUI
+import AppKit
+import Observation
+
+/// Samples the live byte counters of connected tunnels on a short interval and
+/// exposes blink state for the menu bar dots. Runs entirely on the MainActor,
+/// where the `Connection` byte counters are mutated, so reads are race-free.
+@MainActor
+@Observable
+final class MenuBarTrafficMonitor {
+
+    /// Whether any connection is currently connected. Drives menu bar visibility.
+    private(set) var hasActiveConnection = false
+
+    /// TX dot state — toggles each tick while bytes are being sent, off when idle.
+    private(set) var transmitting = false
+
+    /// RX dot state — toggles each tick while bytes are being received, off when idle.
+    private(set) var receiving = false
+
+    private let store: ConnectionStore
+    private var lastBytesSent: Int64 = 0
+    private var lastBytesReceived: Int64 = 0
+    @ObservationIgnored private var pollTask: Task<Void, Never>?
+
+    /// Sampling interval. ~3 Hz gives a visibly blinking dot under sustained load
+    /// without being distracting.
+    private static let sampleInterval = Duration.milliseconds(300)
+
+    init(store: ConnectionStore) {
+        self.store = store
+    }
+
+    /// Begins polling. Safe to call more than once; only the first call starts a loop.
+    func start() {
+        guard pollTask == nil else { return }
+        pollTask = Task { [weak self] in
+            while !Task.isCancelled {
+                guard let self else { return }
+                self.sample()
+                try? await Task.sleep(for: Self.sampleInterval)
+            }
+        }
+    }
+
+    /// Stops polling.
+    func stop() {
+        pollTask?.cancel()
+        pollTask = nil
+    }
+
+    /// One sampling tick: refreshes visibility and computes blink state from the
+    /// change in aggregate bytes since the previous tick.
+    private func sample() {
+        let active = store.connections.filter { $0.state.isActive }
+        hasActiveConnection = !active.isEmpty
+
+        let totalSent = active.reduce(Int64(0)) { $0 + $1.bytesSent }
+        let totalReceived = active.reduce(Int64(0)) { $0 + $1.bytesReceived }
+
+        // Toggle each tick while bytes keep arriving so the dot blinks under
+        // continuous traffic; clear it when nothing moved this interval.
+        transmitting = totalSent > lastBytesSent ? !transmitting : false
+        receiving = totalReceived > lastBytesReceived ? !receiving : false
+
+        // Record current totals as the new baseline. After a disconnect the
+        // counters reset to 0, so the baseline follows them back down and a
+        // reconnect blinks correctly from the first byte.
+        lastBytesSent = totalSent
+        lastBytesReceived = totalReceived
+    }
+}
+
+/// The two-dot label shown in the menu bar.
+struct MenuBarTrafficLabel: View {
+    var monitor: MenuBarTrafficMonitor
+
+    // Dim baseline colour for an inactive dot — visible but clearly "off".
+    private let idleColor = Color.secondary.opacity(0.4)
+    private let dotSize: CGFloat = 5
+
+    var body: some View {
+        // MenuBarExtra treats its label as a single status-item image: an HStack
+        // of two Images clipped to one dot, custom Shapes and symbol-in-Text
+        // rendered nothing. So we rasterise the indicator into one non-template
+        // NSImage and hand that over — the one form the menu bar renders reliably,
+        // with colours preserved (isTemplate = false stops the menu bar tinting it).
+        Image(nsImage: renderedIndicator)
+            .accessibilityLabel("SSH traffic: data sent and received indicators")
+    }
+
+    /// "SSH" stacked above the two coloured dots, rendered to a single bitmap.
+    private var renderedIndicator: NSImage {
+        // isTemplate = false means the image won't auto-adapt to the menu bar's
+        // appearance, so resolve the "SSH" label's colour against the current
+        // system appearance to keep it legible in both light and dark menu bars.
+        let isDark = NSApp.effectiveAppearance
+            .bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
+
+        let indicator = VStack(spacing: 1) {
+            Text("SSH")
+                .font(.system(size: 8, weight: .semibold))
+                .foregroundStyle(.primary)
+            HStack(spacing: 3) {
+                Circle()
+                    .fill(monitor.transmitting ? Color.green : idleColor)
+                    .frame(width: dotSize, height: dotSize)
+                Circle()
+                    .fill(monitor.receiving ? Color.red : idleColor)
+                    .frame(width: dotSize, height: dotSize)
+            }
+        }
+        .environment(\.colorScheme, isDark ? .dark : .light)
+
+        let renderer = ImageRenderer(content: indicator)
+        renderer.scale = NSScreen.main?.backingScaleFactor ?? 2
+        guard let image = renderer.nsImage else { return NSImage() }
+        // Render as a real (coloured) image, not a template the menu bar recolours.
+        image.isTemplate = false
+        return image
+    }
+}
+
+/// The dropdown shown when the menu bar item is clicked: one line per connected
+/// tunnel with its cumulative sent/received totals.
+struct MenuBarTrafficContent: View {
+    var store: ConnectionStore
+
+    var body: some View {
+        let active = store.connections.filter { $0.state.isActive }
+        if active.isEmpty {
+            Text("No active connections")
+        } else {
+            ForEach(active) { connection in
+                Text("\(connection.connectionInfo.name) — ↑ \(connection.bytesSent.formatted(.byteCount(style: .file)))  ↓ \(connection.bytesReceived.formatted(.byteCount(style: .file)))")
+            }
+        }
+    }
+}

--- a/SSH TunnelBuilder/SSH_TunnelBuilderApp.swift
+++ b/SSH TunnelBuilder/SSH_TunnelBuilderApp.swift
@@ -2,7 +2,16 @@ import SwiftUI
 
 @main
 struct SSH_TunnelBuilderApp: App {
-    @State private var connectionStore = ConnectionStore()
+    @State private var connectionStore: ConnectionStore
+    @State private var trafficMonitor: MenuBarTrafficMonitor
+
+    init() {
+        let store = ConnectionStore()
+        let monitor = MenuBarTrafficMonitor(store: store)
+        monitor.start()
+        _connectionStore = State(initialValue: store)
+        _trafficMonitor = State(initialValue: monitor)
+    }
 
     var body: some Scene {
         WindowGroup {
@@ -12,6 +21,18 @@ struct SSH_TunnelBuilderApp: App {
         Settings {
             SettingsView()
                 .environment(connectionStore)
+        }
+
+        // Menu bar traffic indicator. Only inserted while a tunnel is connected.
+        // `hasActiveConnection` must be read here, directly in the scene body, so
+        // Observation registers the dependency and re-evaluates the scene when it
+        // flips — reading it inside the binding's deferred get closure would never
+        // establish that dependency, so the item would never appear. `.constant`
+        // is fine because visibility is driven by the monitor, not user action.
+        MenuBarExtra(isInserted: .constant(trafficMonitor.hasActiveConnection)) {
+            MenuBarTrafficContent(store: connectionStore)
+        } label: {
+            MenuBarTrafficLabel(monitor: trafficMonitor)
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds a menu bar status item ("SSH" label above two dots) that visualises live tunnel traffic:

- **Green TX dot** blinks while data is sent; **red RX dot** blinks while data is received.
- Dots are dim when idle.
- The item appears **only while a tunnel is connected** and disappears when all disconnect.

## Implementation

- **`MenuBarTrafficMonitor`** — MainActor `@Observable` poll loop (~300 ms) that reads the connected `Connection` byte counters (mutated on the MainActor, so reads are race-free), tracks `hasActiveConnection`, and toggles `transmitting`/`receiving` blink flags from the byte delta since the previous tick.
- **`MenuBarTrafficLabel`** — rasterises "SSH" + the two dots into a single non-template `NSImage` via `ImageRenderer`. `MenuBarExtra` only renders a single `Text`/`Image` label reliably; an `HStack` of two images clipped to one, and custom shapes / symbol-in-`Text` rendered nothing. The "SSH" colour is resolved against the current system appearance so it stays legible in light and dark menu bars.
- **`MenuBarTrafficContent`** — dropdown listing each active tunnel's cumulative ↑/↓ totals.
- **`SSH_TunnelBuilderApp`** — `init()` wires/starts the monitor; the `MenuBarExtra` reads `hasActiveConnection` directly in the scene body so Observation re-evaluates and inserts the item on connect.

## Testing

- Builds clean (Swift 6, zero errors).
- Verified live against the `testpin` tunnel: item appears on connect, both dots blink while traffic flows (confirmed by pushing requests through the local forward), and the item hides when idle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)