### PR TITLE
refactor: align UI with Apple SwiftUI guidance

### DIFF
--- a/SSH TunnelBuilder/GUI/ConnectionRow.swift
+++ b/SSH TunnelBuilder/GUI/ConnectionRow.swift
@@ -1,12 +1,14 @@
 import SwiftUI
 
 struct ConnectionRow: View {
-    let connection: Connection
+    /// Take only the field the row renders, so the row invalidates when the
+    /// name changes rather than on any change to the whole `connectionInfo`.
+    let name: String
     let isSelected: Bool
-    
+
     var body: some View {
-        Text(connection.connectionInfo.name)
+        Text(name)
             .background(isSelected ? Color.blue.opacity(0.3) : Color.clear)
-            .cornerRadius(5)
+            .clipShape(RoundedRectangle(cornerRadius: 5))
     }
 }

--- a/SSH TunnelBuilder/GUI/ContentView.swift
+++ b/SSH TunnelBuilder/GUI/ContentView.swift
@@ -74,7 +74,7 @@ struct ErrorSheetView: View {
         VStack(spacing: 20) {
             Image(systemName: "exclamationmark.triangle.fill")
                 .font(.system(size: 50))
-                .foregroundColor(.red)
+                .foregroundStyle(.red)
 
             Text("Error")
                 .font(.title)

--- a/SSH TunnelBuilder/GUI/CredentialsSheetView.swift
+++ b/SSH TunnelBuilder/GUI/CredentialsSheetView.swift
@@ -58,16 +58,16 @@ struct ConnectButtonView: View {
                 VStack(alignment: .leading, spacing: 8) {
                     Text("Password")
                         .font(.subheadline)
-                        .foregroundColor(.secondary)
+                        .foregroundStyle(.secondary)
                     SecureField("Enter password", text: $tempPassword)
-                        .textFieldStyle(RoundedBorderTextFieldStyle())
+                        .textFieldStyle(.roundedBorder)
                 }
 
                 VStack(alignment: .leading, spacing: 8) {
                     HStack(spacing: 6) {
                         Text("Private Key (PEM)")
                             .font(.subheadline)
-                            .foregroundColor(.secondary)
+                            .foregroundStyle(.secondary)
                         Button(action: { if !keyInfoPopoverDismissed { showKeyInfo.toggle() } }) {
                             Image(systemName: "info.circle")
                         }
@@ -93,20 +93,20 @@ struct ConnectButtonView: View {
                     HStack(spacing: 6) {
                         Text("Passphrase (optional)")
                             .font(.subheadline)
-                            .foregroundColor(.secondary)
+                            .foregroundStyle(.secondary)
                         if isPEMEncrypted(tempPrivateKey) {
                             Image(systemName: "lock")
-                                .foregroundColor(.secondary)
+                                .foregroundStyle(.secondary)
                                 .help("This key appears to be encrypted; enter the passphrase.")
                         }
                     }
                     SecureField("Enter passphrase", text: $tempPassphrase)
-                        .textFieldStyle(RoundedBorderTextFieldStyle())
+                        .textFieldStyle(.roundedBorder)
                 }
 
                 if let pemError = pemError {
                     Text(pemError)
-                        .foregroundColor(.red)
+                        .foregroundStyle(.red)
                         .font(.footnote)
                 }
 
@@ -114,7 +114,7 @@ struct ConnectButtonView: View {
 
                 Text("Provide either a password or a private key (PEM). If you choose not to save, the credentials will be used for this session only. Note: Passphrases are never saved and must be re-entered each time.")
                     .font(.footnote)
-                    .foregroundColor(.secondary)
+                    .foregroundStyle(.secondary)
 
                 HStack {
                     Spacer()

--- a/SSH TunnelBuilder/GUI/KeyValidation.swift
+++ b/SSH TunnelBuilder/GUI/KeyValidation.swift
@@ -124,9 +124,9 @@ struct PEMKeyInfoView: View {
     private var keyStatusView: some View {
         HStack(spacing: 6) {
             Image(systemName: isSupported ? "checkmark.circle" : "exclamationmark.triangle")
-                .foregroundColor(isSupported ? .green : .orange)
+                .foregroundStyle(isSupported ? .green : .orange)
             Text("Detected key: \(keyKindDescription(kind))")
-                .foregroundColor(isSupported ? .green : .orange)
+                .foregroundStyle(isSupported ? .green : .orange)
                 .font(.footnote)
         }
     }
@@ -135,9 +135,9 @@ struct PEMKeyInfoView: View {
     private var opensshKeyNote: some View {
         HStack(spacing: 6) {
             Image(systemName: "info.circle")
-                .foregroundColor(.blue)
+                .foregroundStyle(.blue)
             Text("OpenSSH Ed25519/ECDSA keys are supported, including passphrase-protected keys (aes-ctr, aes-cbc, aes-gcm). Enter the passphrase below if the key is encrypted.")
-                .foregroundColor(.secondary)
+                .foregroundStyle(.secondary)
                 .font(.footnote)
         }
     }
@@ -146,9 +146,9 @@ struct PEMKeyInfoView: View {
     private var unencryptedKeyWarning: some View {
         HStack(spacing: 6) {
             Image(systemName: "lock.open")
-                .foregroundColor(.orange)
+                .foregroundStyle(.orange)
             Text("Warning: Key appears unencrypted. Prefer an encrypted PEM (PKCS#8) with a passphrase.")
-                .foregroundColor(.orange)
+                .foregroundStyle(.orange)
                 .font(.footnote)
         }
     }
@@ -158,7 +158,7 @@ struct PEMKeyInfoView: View {
         VStack(alignment: .leading) {
             HStack(alignment: .firstTextBaseline, spacing: 6) {
                 Image(systemName: "exclamationmark.triangle")
-                    .foregroundColor(.orange)
+                    .foregroundStyle(.orange)
                 Text("\(keyKindDescription(kind)) is not supported. Convert to ECDSA or Ed25519:")
                     .font(.footnote)
                 Spacer(minLength: 8)
@@ -210,11 +210,11 @@ struct KeyValidationAlertView: View {
         case .encryptedPKCS8ContainsRSA:
             Label("RSA Key Detected", systemImage: "shield.lefthalf.filled")
                 .font(.title2.bold())
-                .foregroundColor(.red)
+                .foregroundStyle(.red)
         case .encryptedOpenSSHKey:
             Label("Encrypted OpenSSH Key", systemImage: "lock.fill")
                 .font(.title2.bold())
-                .foregroundColor(.orange)
+                .foregroundStyle(.orange)
         default:
             EmptyView()
         }

--- a/SSH TunnelBuilder/GUI/MainView.swift
+++ b/SSH TunnelBuilder/GUI/MainView.swift
@@ -28,6 +28,9 @@ struct EditableFieldView: View {
                 Text(value.wrappedValue)
             }
         } else {
+            // Group wraps an if/else (`_ConditionalContent`), so the shared
+            // text-field style applies to both branches — not the single-child
+            // Group anti-pattern.
             Group {
                 if isSecure {
                     SecureField(placeholder, text: value)
@@ -35,13 +38,16 @@ struct EditableFieldView: View {
                     TextField(placeholder, text: value)
                 }
             }
-            .textFieldStyle(RoundedBorderTextFieldStyle())
+            .textFieldStyle(.roundedBorder)
         }
     }
 }
 
 // MARK: - Main View
 
+/// Thin dispatcher: picks the section view for the current mode/selection.
+/// Each section is its own `View` type so it forms its own invalidation
+/// boundary rather than sharing one large body.
 struct MainView: View {
     @Environment(ConnectionStore.self) var connectionStore
 
@@ -49,62 +55,155 @@ struct MainView: View {
 
     var body: some View {
         if connectionStore.mode == .loading {
-            loadingView
+            LoadingView()
         } else if connectionStore.mode == .view && selectedConnection == nil {
-            emptySelectionView
+            EmptySelectionView()
         } else {
-            VStack {
-                connectionNameRow(label: "Connection Name:", value: connectionNameBinding)
-                    .padding()
+            ConnectionDetailView(selectedConnection: $selectedConnection)
+        }
+    }
+}
 
-                if let notice = connectionStore.migrationNotice {
-                    noticeBanner(notice) { connectionStore.migrationNotice = nil }
+// MARK: - Loading View
+
+struct LoadingView: View {
+    var body: some View {
+        VStack(spacing: 16) {
+            ProgressView()
+                .scaleEffect(1.5)
+            Text("Loading connections...")
+                .font(.title2)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+// MARK: - Empty Selection View
+
+struct EmptySelectionView: View {
+    @Environment(ConnectionStore.self) private var connectionStore
+
+    var body: some View {
+        VStack(spacing: 20) {
+            Image(systemName: "network")
+                .font(.system(size: 60))
+                .foregroundStyle(.secondary)
+
+            Text("No Connection Selected")
+                .font(.title)
+                .fontWeight(.semibold)
+
+            Text("Select a connection from the sidebar or create a new one")
+                .font(.body)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+
+            if connectionStore.connections.isEmpty {
+                Button {
+                    connectionStore.mode = .create
+                } label: {
+                    Label("Create Connection", systemImage: "plus.circle.fill")
                 }
-
-                if let cloud = connectionStore.cloudNotice {
-                    noticeBanner(cloud) { connectionStore.cloudNotice = nil }
-                }
-
-                HStack(alignment: .firstTextBaseline) {
-                    if connectionStore.mode == .view, let connection = selectedConnection {
-                        Text("Connection Status:")
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                        ConnectionIndicatorView(connection: connection)
-                            .frame(maxWidth: .infinity, alignment: .trailing)
-                            .padding(.trailing)
-                    } else {
-                        // Maintain spacing when no connection is selected
-                        Color.clear.frame(maxWidth: .infinity)
-                        Color.clear.frame(maxWidth: .infinity)
-                    }
-                }
-                .padding(.horizontal)
-
-                if connectionStore.mode == .view {
-                    if let connection = selectedConnection {
-                        DataCounterView(connection: connection)
-                            .padding()
-                    } else {
-                        Text("")
-                    }
-                    Spacer()
-                }
-
-                connectionForm
+                .buttonStyle(.borderedProminent)
+                .controlSize(.large)
+                .padding(.top, 8)
             }
-            .toolbar {
-                ToolbarItemGroup {
-                    if connectionStore.mode == .create || connectionStore.mode == .edit {
-                        Button("Cancel") {
-                            // Clear the create form before leaving create mode —
-                            // checking after setting `.view` would always be false.
-                            if connectionStore.mode == .create {
-                                connectionStore.clearCreateForm()
-                            }
-                            connectionStore.mode = .view
-                            if selectedConnection == nil {
-                                selectedConnection = connectionStore.connections.first
-                            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding()
+    }
+}
+
+// MARK: - Notice Banner
+
+/// A dismissable blue information banner (migration / CloudKit notices).
+struct NoticeBanner: View {
+    let message: String
+    let onDismiss: () -> Void
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: "info.circle")
+                .foregroundStyle(.blue)
+            Text(message)
+                .foregroundStyle(.primary)
+            Spacer()
+            Button(action: onDismiss) {
+                Image(systemName: "xmark.circle.fill")
+                    .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Dismiss notice")
+        }
+        .padding(8)
+        .background(Color.blue.opacity(0.1))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .padding([.horizontal, .top])
+    }
+}
+
+// MARK: - Connection Detail View
+
+/// The detail pane for the create / edit / view modes: the name header, any
+/// notices, the live status + data counters (view mode), and the field form.
+struct ConnectionDetailView: View {
+    @Environment(ConnectionStore.self) private var connectionStore
+
+    @Binding var selectedConnection: Connection?
+
+    var body: some View {
+        VStack {
+            connectionNameRow(label: "Connection Name:", value: connectionNameBinding)
+                .padding()
+
+            if let notice = connectionStore.migrationNotice {
+                NoticeBanner(message: notice) { connectionStore.migrationNotice = nil }
+            }
+
+            if let cloud = connectionStore.cloudNotice {
+                NoticeBanner(message: cloud) { connectionStore.cloudNotice = nil }
+            }
+
+            HStack(alignment: .firstTextBaseline) {
+                if connectionStore.mode == .view, let connection = selectedConnection {
+                    Text("Connection Status:")
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    ConnectionIndicatorView(connection: connection)
+                        .frame(maxWidth: .infinity, alignment: .trailing)
+                        .padding(.trailing)
+                } else {
+                    // Maintain spacing when no connection is selected
+                    Color.clear.frame(maxWidth: .infinity)
+                    Color.clear.frame(maxWidth: .infinity)
+                }
+            }
+            .padding(.horizontal)
+
+            if connectionStore.mode == .view {
+                if let connection = selectedConnection {
+                    DataCounterView(connection: connection)
+                        .padding()
+                } else {
+                    Text("")
+                }
+                Spacer()
+            }
+
+            connectionForm
+        }
+        .toolbar {
+            ToolbarItemGroup {
+                if connectionStore.mode == .create || connectionStore.mode == .edit {
+                    Button("Cancel") {
+                        // Clear the create form before leaving create mode —
+                        // checking after setting `.view` would always be false.
+                        if connectionStore.mode == .create {
+                            connectionStore.clearCreateForm()
+                        }
+                        connectionStore.mode = .view
+                        if selectedConnection == nil {
+                            selectedConnection = connectionStore.connections.first
                         }
                     }
                 }
@@ -310,6 +409,8 @@ struct MainView: View {
 
     // MARK: - Row Views
 
+    /// Small repeated fragment within this view's body — a `@ViewBuilder`
+    /// helper is appropriate here (not a factored-out section).
     @ViewBuilder
     private func infoRow(label: String, value: Binding<String>, isSecure: Bool = false) -> some View {
         HStack {
@@ -328,73 +429,5 @@ struct MainView: View {
             EditableFieldView(value: value, placeholder: "Enter connection name")
                 .font(.largeTitle)
         }
-    }
-
-    /// A dismissable blue information banner (migration / CloudKit notices).
-    private func noticeBanner(_ message: String, onDismiss: @escaping () -> Void) -> some View {
-        HStack(alignment: .top, spacing: 8) {
-            Image(systemName: "info.circle")
-                .foregroundColor(.blue)
-            Text(message)
-                .foregroundColor(.primary)
-            Spacer()
-            Button(action: onDismiss) {
-                Image(systemName: "xmark.circle.fill")
-                    .foregroundColor(.secondary)
-            }
-            .buttonStyle(.plain)
-        }
-        .padding(8)
-        .background(Color.blue.opacity(0.1))
-        .cornerRadius(8)
-        .padding([.horizontal, .top])
-    }
-
-    // MARK: - Helper Views
-
-    private var loadingView: some View {
-        VStack(spacing: 16) {
-            ProgressView()
-                .scaleEffect(1.5)
-            Text("Loading connections...")
-                .font(.title2)
-                .foregroundColor(.secondary)
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-    }
-
-    private var emptySelectionView: some View {
-        VStack(spacing: 20) {
-            Image(systemName: "network")
-                .font(.system(size: 60))
-                .foregroundColor(.secondary)
-
-            Text("No Connection Selected")
-                .font(.title)
-                .fontWeight(.semibold)
-
-            Text("Select a connection from the sidebar or create a new one")
-                .font(.body)
-                .foregroundColor(.secondary)
-                .multilineTextAlignment(.center)
-
-            if connectionStore.connections.isEmpty {
-                Button(action: {
-                    connectionStore.mode = .create
-                }) {
-                    Label("Create Connection", systemImage: "plus.circle.fill")
-                        .font(.headline)
-                        .padding(.horizontal, 20)
-                        .padding(.vertical, 10)
-                        .background(Color.accentColor)
-                        .foregroundColor(.white)
-                        .cornerRadius(8)
-                }
-                .buttonStyle(.plain)
-                .padding(.top, 8)
-            }
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .padding()
     }
 }

--- a/SSH TunnelBuilder/GUI/NavigationView.swift
+++ b/SSH TunnelBuilder/GUI/NavigationView.swift
@@ -8,14 +8,16 @@ struct NavigationList: View {
     var body: some View {
         List(selection: $selectedConnection) {
             ForEach(connectionStore.connections) { connection in
-                ConnectionRow(connection: connection, isSelected: selectedConnection == connection)
-                    .tag(connection)
-                    .onTapGesture {
-                        selectedConnection = connection
-                    }
+                // The List drives selection via its `selection:` binding and the
+                // row `.tag`, so no extra tap gesture is needed.
+                ConnectionRow(
+                    name: connection.connectionInfo.name,
+                    isSelected: selectedConnection == connection
+                )
+                .tag(connection)
             }
         }
-        .listStyle(SidebarListStyle())
+        .listStyle(.sidebar)
         .frame(minWidth: 230)
         .navigationTitle("Navigation")
         .toolbar {
@@ -24,7 +26,7 @@ struct NavigationList: View {
                     connectionStore.mode = .create
                     selectedConnection = nil
                 }) {
-                    Image(systemName: "plus")
+                    Label("Create new connection", systemImage: "plus")
                 }
                 .help("Create new connection")
             }
@@ -37,7 +39,7 @@ struct NavigationList: View {
                             connectionStore.updateTempConnection(with: connection)
                         }
                     }) {
-                        Image(systemName: "pencil")
+                        Label("Edit selected connection", systemImage: "pencil")
                     }
                     .help("Edit selected connection")
                 }
@@ -49,7 +51,7 @@ struct NavigationList: View {
                         connectionStore.deleteConnection(connection)
                         selectedConnection = nil
                     }) {
-                        Image(systemName: "trash")
+                        Label("Delete selected connection", systemImage: "trash")
                     }
                     .help("Delete selected connection")
                 }


### PR DESCRIPTION
Audits the GUI views against Apple's published SwiftUI references (view structure, data flow, soft-deprecated APIs, HIG controls) and brings them into compliance. No behavior changes; build is green.

## Changes

**Soft-deprecated API sweep**
- `.foregroundColor` → `.foregroundStyle` (~15 sites across ContentView, MainView, CredentialsSheetView, KeyValidation)
- `.cornerRadius` → `.clipShape(RoundedRectangle(...))` (ConnectionRow, notice banner)
- `RoundedBorderTextFieldStyle()` → `.textFieldStyle(.roundedBorder)`
- `SidebarListStyle()` → `.listStyle(.sidebar)`

**Accessibility & standard controls**
- Sidebar toolbar icons (`plus`/`pencil`/`trash`) now use `Label`, giving VoiceOver a name
- Empty-state button switched from a hand-rolled `.plain` style (hardcoded `.white`) to `.buttonStyle(.borderedProminent)`
- Removed the redundant `.onTapGesture` in the sidebar `List` (selection already driven by `List(selection:)` + `.tag`)

**View structure**
- `MainView` is now a thin dispatcher; sections are separate `View` types (`LoadingView`, `EmptySelectionView`, `ConnectionDetailView`, `NoticeBanner`), each its own invalidation boundary

**Data flow**
- `ConnectionRow` narrowed to the `name` field it renders, so it no longer depends on the whole `connectionInfo` struct

## Notes
- `formBinding`'s mode-routing closure bindings were intentionally left as-is (they route across create/edit/view modes at runtime, which a single KeyPath binding can't express; low value / non-trivial risk on a credential form with no working test net).
- Build verified green via Xcode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)