### PR TITLE
Encrypted import/export, menu commands, Xcode Cloud setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,11 @@ iOSInjectionProject/
 SSH TunnelBuilder.xcworkspace/xcshareddata/*
 !SSH TunnelBuilder.xcworkspace/xcshareddata/swiftpm/
 !SSH TunnelBuilder.xcworkspace/xcshareddata/swiftpm/Package.resolved
+
+# Track the project's shared scheme — Xcode Cloud requires a shared scheme
+# checked into source control to build. Everything else under the project's
+# xcshareddata/ (ignored on line 9) stays ignored.
+!SSH TunnelBuilder.xcodeproj/xcshareddata/
+SSH TunnelBuilder.xcodeproj/xcshareddata/*
+!SSH TunnelBuilder.xcodeproj/xcshareddata/xcschemes/
+!SSH TunnelBuilder.xcodeproj/xcshareddata/xcschemes/*.xcscheme

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,37 @@
 - **PEMDecryptor.swift**: PKCS#8 key decryption with PBKDF2
 - **BcryptPBKDF.swift**: Blowfish + `bcrypt_pbkdf` (from scratch; not in CryptoKit), used to key OpenSSH key decryption
 - **OpenSSHKeyDecryptor.swift**: decrypts encrypted `openssh-key-v1` private sections (AES-CTR/CBC/GCM)
+- **ConnectionTransfer.swift**: encrypted import/export codec (see below)
+- **ExportDocument.swift**: `.sshtunnels` `UTType` + `FileDocument` for the file dialogs
+- **PassphrasePromptView.swift**: reusable encrypt/decrypt passphrase sheet
+- **AppCommands.swift**: app menu bar commands (`Commands`) operating on the shared store
+
+## Import / Export
+
+Connections can be exported to and imported from an encrypted `.sshtunnels` file
+via the **File** menu (`File ▸ Export ▸ Export All… / Export Selected…`, and
+`File ▸ Import Connections…`).
+
+- **Format:** a plaintext JSON envelope (format/version + KDF params) wrapping a
+  base64 AES-256-GCM blob. No secret ever touches disk in cleartext — only the
+  ciphertext does. On-disk type is a branded `.sshtunnels` UTI conforming to
+  `public.json` (declared in `SSH-TunnelBuilder-Info.plist`).
+- **Crypto:** passphrase → PBKDF2-HMAC-SHA256 (600k iterations, 16-byte random
+  salt) → 256-bit key → `AES.GCM`. A wrong passphrase fails as a GCM tag
+  mismatch and surfaces a friendly error. All in `ConnectionTransfer` (pure,
+  `nonisolated`); the heavy KDF runs off the main actor.
+- **Secrets:** an export is a *full* backup. `ConnectionStore.makeExportPayload`
+  reads passwords / private keys from the Keychain (may prompt for Touch ID);
+  `importConnections` mints **fresh ids** (so imports never overwrite existing
+  CloudKit records) and writes secrets back through the normal save path.
+  `privateKeyPassphrase` is never persisted, so it always exports empty.
+- **UI plumbing:** menu commands set `ConnectionStore.transferRequest`;
+  `ContentView` observes it and runs the passphrase sheet + `fileExporter` /
+  `fileImporter`. Selection is hoisted into the store (`selectedConnection`) so
+  the commands can act on it. The file dialogs require the sandbox file-access
+  build settings (`ENABLE_APP_SANDBOX` + `ENABLE_USER_SELECTED_FILES = readwrite`).
+  Each presentation sits on its own `.background` host — macOS SwiftUI only drives
+  one presentation per view.
 
 ## Private key support
 

--- a/SSH TunnelBuilder.xcodeproj/project.pbxproj
+++ b/SSH TunnelBuilder.xcodeproj/project.pbxproj
@@ -58,12 +58,20 @@
 			);
 			target = F4ABBF5327DFDF730097436A /* SSH TunnelBuilder */;
 		};
+		F4BAFED02FE1F22400D898D2 /* Exceptions for "SSH TunnelBuilder" folder in "SSH TunnelBuilder" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				"SSH-TunnelBuilder-Info.plist",
+			);
+			target = F4ABBF5327DFDF730097436A /* SSH TunnelBuilder */;
+		};
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		F47CCD262FDB4F1400BBECDF /* SSH TunnelBuilder */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
+				F4BAFED02FE1F22400D898D2 /* Exceptions for "SSH TunnelBuilder" folder in "SSH TunnelBuilder" target */,
 				F47CCD382FDB4F1500BBECDF /* Exceptions for "SSH TunnelBuilder" folder in "SSH TunnelBuilderTests" target */,
 			);
 			path = "SSH TunnelBuilder";
@@ -426,7 +434,9 @@
 				ENABLE_RESOURCE_ACCESS_LOCATION = NO;
 				ENABLE_RESOURCE_ACCESS_PRINTING = NO;
 				ENABLE_RESOURCE_ACCESS_USB = NO;
+				ENABLE_USER_SELECTED_FILES = readwrite;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "SSH-TunnelBuilder-Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "SSH TunnelBuilder";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Comraich ANS";
@@ -435,7 +445,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.6;
-				MARKETING_VERSION = 2.0;
+				MARKETING_VERSION = 2.2;
 				PRODUCT_BUNDLE_IDENTIFIER = no.comraich.sshTunnelBuilder;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -472,7 +482,9 @@
 				ENABLE_RESOURCE_ACCESS_LOCATION = NO;
 				ENABLE_RESOURCE_ACCESS_PRINTING = NO;
 				ENABLE_RESOURCE_ACCESS_USB = NO;
+				ENABLE_USER_SELECTED_FILES = readwrite;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "SSH-TunnelBuilder-Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "SSH TunnelBuilder";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Comraich ANS";
@@ -481,7 +493,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.6;
-				MARKETING_VERSION = 2.0;
+				MARKETING_VERSION = 2.2;
 				PRODUCT_BUNDLE_IDENTIFIER = no.comraich.sshTunnelBuilder;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -504,7 +516,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MACOSX_DEPLOYMENT_TARGET = 15.6;
-				MARKETING_VERSION = 2.0;
+				MARKETING_VERSION = 2.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "no.comraich.SSH-TunnelBuilderTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = NO;
@@ -529,7 +541,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MACOSX_DEPLOYMENT_TARGET = 15.6;
-				MARKETING_VERSION = 2.0;
+				MARKETING_VERSION = 2.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "no.comraich.SSH-TunnelBuilderTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = NO;

--- a/SSH TunnelBuilder.xcodeproj/xcshareddata/xcschemes/SSH TunnelBuilder.xcscheme
+++ b/SSH TunnelBuilder.xcodeproj/xcshareddata/xcschemes/SSH TunnelBuilder.xcscheme
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2600"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F4ABBF5327DFDF730097436A"
+               BuildableName = "SSH TunnelBuilder.app"
+               BlueprintName = "SSH TunnelBuilder"
+               ReferencedContainer = "container:SSH TunnelBuilder.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F4CB866A2EE49D1D0066AEDA"
+               BuildableName = "SSH TunnelBuilderTests.xctest"
+               BlueprintName = "SSH TunnelBuilderTests"
+               ReferencedContainer = "container:SSH TunnelBuilder.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F4ABBF5327DFDF730097436A"
+            BuildableName = "SSH TunnelBuilder.app"
+            BlueprintName = "SSH TunnelBuilder"
+            ReferencedContainer = "container:SSH TunnelBuilder.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F4ABBF5327DFDF730097436A"
+            BuildableName = "SSH TunnelBuilder.app"
+            BlueprintName = "SSH TunnelBuilder"
+            ReferencedContainer = "container:SSH TunnelBuilder.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/SSH TunnelBuilder/Classes/ConnectionStore.swift
+++ b/SSH TunnelBuilder/Classes/ConnectionStore.swift
@@ -51,8 +51,25 @@ class ConnectionStore {
         case view
         case loading
     }
-    
+
+    /// A menu command's request to begin an import/export flow. `ContentView`
+    /// observes this, runs the passphrase prompt + file dialog, then clears it.
+    enum TransferRequest: Equatable {
+        case exportAll
+        case exportSelected
+        case importConnections
+    }
+
     var mode: Mode = .loading
+
+    /// The connection currently selected in the sidebar. Hoisted into the store
+    /// (rather than living as `ContentView` state) so the app's menu commands can
+    /// read and act on the selection — Connect/Disconnect/Edit/Delete/Export.
+    var selectedConnection: Connection?
+
+    /// Set by a menu command to ask `ContentView` to start a transfer flow.
+    var transferRequest: TransferRequest?
+
     private(set) var connections: [Connection] = []
     private(set) var tempConnection: Connection?
 
@@ -638,6 +655,59 @@ class ConnectionStore {
         }
     }
     
+    // MARK: - Import / Export
+
+    /// Builds an export payload for the given connections, reading their secrets
+    /// from the Keychain. Reading protected credentials may prompt for Touch ID /
+    /// password. `privateKeyPassphrase` is never persisted, so it exports empty.
+    func makeExportPayload(for connections: [Connection]) -> ExportPayload {
+        let exported = connections.map { connection -> ExportedConnection in
+            let info = connection.connectionInfo
+            let tunnel = connection.tunnelInfo
+            return ExportedConnection(
+                name: info.name,
+                serverAddress: info.serverAddress,
+                portNumber: info.portNumber,
+                username: info.username,
+                password: credentialsStore.loadPassword(for: connection.id) ?? "",
+                privateKey: credentialsStore.loadPrivateKey(for: connection.id) ?? "",
+                privateKeyPassphrase: "",
+                knownHostKey: info.knownHostKey,
+                localPort: tunnel.localPort,
+                remoteServer: tunnel.remoteServer,
+                remotePort: tunnel.remotePort
+            )
+        }
+        return ExportPayload(connections: exported)
+    }
+
+    /// Imports connections from a decrypted payload. Each becomes a brand-new
+    /// connection (fresh id / CloudKit record) saved through the normal path, so
+    /// secrets land in the Keychain and nothing overwrites an existing record.
+    /// Returns the number of connections queued for import.
+    @discardableResult
+    func importConnections(from payload: ExportPayload) -> Int {
+        for item in payload.connections {
+            let connectionInfo = ConnectionInfo(
+                name: item.name,
+                serverAddress: item.serverAddress,
+                portNumber: item.portNumber,
+                username: item.username,
+                password: item.password,
+                privateKey: item.privateKey,
+                privateKeyPassphrase: item.privateKeyPassphrase,
+                knownHostKey: item.knownHostKey
+            )
+            let tunnelInfo = TunnelInfo(
+                localPort: item.localPort,
+                remoteServer: item.remoteServer,
+                remotePort: item.remotePort
+            )
+            newConnection(connectionInfo: connectionInfo, tunnelInfo: tunnelInfo)
+        }
+        return payload.connections.count
+    }
+
     private func migrateSecret(from record: CKRecord, field: String, for uuid: UUID, saveAction: (String, UUID) -> Void) -> Bool {
         if let encodedValue = record[field] as? String, !encodedValue.isEmpty {
             saveAction(encodedValue, uuid)

--- a/SSH TunnelBuilder/Classes/ConnectionTransfer.swift
+++ b/SSH TunnelBuilder/Classes/ConnectionTransfer.swift
@@ -179,24 +179,26 @@ enum ConnectionTransfer {
 
     /// Derives a 256-bit key from `passphrase` + `salt` via PBKDF2-HMAC-SHA256.
     private static func deriveKey(passphrase: String, salt: Data, iterations: Int) throws -> SymmetricKey {
-        let passwordBytes = Array(passphrase.utf8) // guaranteed non-empty by callers
+        // `utf8CString` is already `[CChar]` (null-terminated), so we can hand its
+        // pointer straight to PBKDF2 without a `withMemoryRebound` layer — keeping
+        // the nesting to two closures. The length excludes the trailing NUL.
+        let passwordChars = Array(passphrase.utf8CString) // guaranteed non-empty by callers
+        let saltBytes = Array(salt)
         var derived = [UInt8](repeating: 0, count: keyByteCount)
 
-        let status: Int32 = passwordBytes.withUnsafeBufferPointer { pw in
-            pw.baseAddress!.withMemoryRebound(to: CChar.self, capacity: pw.count) { passwordPtr in
-                salt.withUnsafeBytes { saltBuffer in
-                    CCKeyDerivationPBKDF(
-                        CCPBKDFAlgorithm(kCCPBKDF2),
-                        passwordPtr,
-                        pw.count,
-                        saltBuffer.bindMemory(to: UInt8.self).baseAddress!,
-                        salt.count,
-                        CCPseudoRandomAlgorithm(kCCPRFHmacAlgSHA256),
-                        UInt32(iterations),
-                        &derived,
-                        derived.count
-                    )
-                }
+        let status: Int32 = passwordChars.withUnsafeBufferPointer { pw in
+            saltBytes.withUnsafeBufferPointer { saltPtr in
+                CCKeyDerivationPBKDF(
+                    CCPBKDFAlgorithm(kCCPBKDF2),
+                    pw.baseAddress,
+                    pw.count - 1,
+                    saltPtr.baseAddress,
+                    saltBytes.count,
+                    CCPseudoRandomAlgorithm(kCCPRFHmacAlgSHA256),
+                    UInt32(iterations),
+                    &derived,
+                    derived.count
+                )
             }
         }
         guard status == kCCSuccess else { throw ConnectionTransferError.keyDerivationFailed }

--- a/SSH TunnelBuilder/Classes/ConnectionTransfer.swift
+++ b/SSH TunnelBuilder/Classes/ConnectionTransfer.swift
@@ -1,0 +1,206 @@
+import Foundation
+import CryptoKit
+import CommonCrypto
+
+// MARK: - Transfer DTOs
+
+/// A single connection as written to / read from an export file. Carries the
+/// full secret set because an export is a complete, passphrase-encrypted backup.
+///
+/// There is deliberately no `id` / `recordID`: importing mints fresh identifiers
+/// so restored connections become *new* records rather than colliding with — or
+/// silently overwriting — existing ones. `privateKeyPassphrase` is included for
+/// completeness but is normally empty, since the app never persists it.
+struct ExportedConnection: Codable, Equatable {
+    var name: String
+    var serverAddress: String
+    var portNumber: String
+    var username: String
+    var password: String
+    var privateKey: String
+    var privateKeyPassphrase: String
+    var knownHostKey: String
+    var localPort: String
+    var remoteServer: String
+    var remotePort: String
+}
+
+/// The decrypted body of an export file.
+struct ExportPayload: Codable, Equatable {
+    var connections: [ExportedConnection]
+}
+
+// MARK: - Errors
+
+enum ConnectionTransferError: LocalizedError {
+    case emptyPassphrase
+    case wrongPassphraseOrCorruptFile
+    case unrecognizedFormat
+    case unsupportedVersion(Int)
+    case malformed(String)
+    case randomGenerationFailed
+    case keyDerivationFailed
+
+    var errorDescription: String? {
+        switch self {
+        case .emptyPassphrase:
+            return "Enter a passphrase to encrypt or open the export file."
+        case .wrongPassphraseOrCorruptFile:
+            return "Couldn’t decrypt the file. The passphrase may be wrong, or the file may be damaged."
+        case .unrecognizedFormat:
+            return "This doesn’t look like an SSH TunnelBuilder export file."
+        case .unsupportedVersion(let version):
+            return "This export file uses a newer format (version \(version)) than this app understands. Update the app and try again."
+        case .malformed(let detail):
+            return "The export file is malformed: \(detail)"
+        case .randomGenerationFailed:
+            return "Couldn’t generate secure random data for encryption."
+        case .keyDerivationFailed:
+            return "Couldn’t derive an encryption key from the passphrase."
+        }
+    }
+}
+
+// MARK: - On-disk envelope
+
+/// The plaintext header stored alongside the ciphertext. It describes how to
+/// derive the key and which cipher was used, but holds no secret material — the
+/// connection data lives only inside `data`.
+private struct ExportEnvelope: Codable {
+    let format: String
+    let version: Int
+    let kdf: String
+    let iterations: Int
+    let salt: String   // base64
+    let cipher: String
+    let data: String   // base64 of AES-GCM combined box (nonce + ciphertext + tag)
+
+    static let expectedFormat = "ssh-tunnelbuilder-export"
+    static let currentVersion = 1
+    static let kdfName = "pbkdf2-hmac-sha256"
+    static let cipherName = "aes-256-gcm"
+}
+
+// MARK: - Encrypt / Decrypt
+
+/// Stateless codec that turns an `ExportPayload` into an encrypted file blob and
+/// back. Pure and `nonisolated`, so the slow key-derivation step can run off the
+/// main actor.
+enum ConnectionTransfer {
+    /// PBKDF2 iteration count. OWASP's recommended floor for PBKDF2-HMAC-SHA256.
+    static let pbkdf2Iterations = 600_000
+    private static let saltByteCount = 16
+    private static let keyByteCount = 32 // AES-256
+
+    /// Encrypts `payload` under `passphrase`, returning the bytes to write to disk.
+    static func encrypt(_ payload: ExportPayload, passphrase: String) throws -> Data {
+        guard !passphrase.isEmpty else { throw ConnectionTransferError.emptyPassphrase }
+
+        let plaintext = try JSONEncoder().encode(payload)
+        let salt = try randomBytes(count: saltByteCount)
+        let key = try deriveKey(passphrase: passphrase, salt: salt, iterations: pbkdf2Iterations)
+
+        let sealed = try AES.GCM.seal(plaintext, using: key)
+        guard let combined = sealed.combined else {
+            // Only nil for a custom nonce; the default seal always produces one.
+            throw ConnectionTransferError.malformed("missing sealed box")
+        }
+
+        let envelope = ExportEnvelope(
+            format: ExportEnvelope.expectedFormat,
+            version: ExportEnvelope.currentVersion,
+            kdf: ExportEnvelope.kdfName,
+            iterations: pbkdf2Iterations,
+            salt: salt.base64EncodedString(),
+            cipher: ExportEnvelope.cipherName,
+            data: combined.base64EncodedString()
+        )
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        return try encoder.encode(envelope)
+    }
+
+    /// Decrypts file `data` with `passphrase`, returning the connection payload.
+    static func decrypt(_ data: Data, passphrase: String) throws -> ExportPayload {
+        guard !passphrase.isEmpty else { throw ConnectionTransferError.emptyPassphrase }
+
+        let envelope: ExportEnvelope
+        do {
+            envelope = try JSONDecoder().decode(ExportEnvelope.self, from: data)
+        } catch {
+            throw ConnectionTransferError.unrecognizedFormat
+        }
+
+        guard envelope.format == ExportEnvelope.expectedFormat else {
+            throw ConnectionTransferError.unrecognizedFormat
+        }
+        guard envelope.version <= ExportEnvelope.currentVersion else {
+            throw ConnectionTransferError.unsupportedVersion(envelope.version)
+        }
+        guard envelope.kdf == ExportEnvelope.kdfName, envelope.cipher == ExportEnvelope.cipherName else {
+            throw ConnectionTransferError.malformed("unsupported kdf/cipher")
+        }
+        guard
+            let salt = Data(base64Encoded: envelope.salt),
+            let combined = Data(base64Encoded: envelope.data)
+        else {
+            throw ConnectionTransferError.malformed("invalid base64")
+        }
+
+        let key = try deriveKey(passphrase: passphrase, salt: salt, iterations: envelope.iterations)
+
+        let plaintext: Data
+        do {
+            let box = try AES.GCM.SealedBox(combined: combined)
+            plaintext = try AES.GCM.open(box, using: key)
+        } catch {
+            // Tag mismatch (wrong passphrase) or truncated ciphertext both land here.
+            throw ConnectionTransferError.wrongPassphraseOrCorruptFile
+        }
+
+        do {
+            return try JSONDecoder().decode(ExportPayload.self, from: plaintext)
+        } catch {
+            throw ConnectionTransferError.malformed("decoded payload was not valid")
+        }
+    }
+
+    // MARK: - Crypto helpers
+
+    private static func randomBytes(count: Int) throws -> Data {
+        var bytes = Data(count: count)
+        let status = bytes.withUnsafeMutableBytes { buffer in
+            SecRandomCopyBytes(kSecRandomDefault, count, buffer.baseAddress!)
+        }
+        guard status == errSecSuccess else { throw ConnectionTransferError.randomGenerationFailed }
+        return bytes
+    }
+
+    /// Derives a 256-bit key from `passphrase` + `salt` via PBKDF2-HMAC-SHA256.
+    private static func deriveKey(passphrase: String, salt: Data, iterations: Int) throws -> SymmetricKey {
+        let passwordBytes = Array(passphrase.utf8) // guaranteed non-empty by callers
+        var derived = [UInt8](repeating: 0, count: keyByteCount)
+
+        let status: Int32 = passwordBytes.withUnsafeBufferPointer { pw in
+            pw.baseAddress!.withMemoryRebound(to: CChar.self, capacity: pw.count) { passwordPtr in
+                salt.withUnsafeBytes { saltBuffer in
+                    CCKeyDerivationPBKDF(
+                        CCPBKDFAlgorithm(kCCPBKDF2),
+                        passwordPtr,
+                        pw.count,
+                        saltBuffer.bindMemory(to: UInt8.self).baseAddress!,
+                        salt.count,
+                        CCPseudoRandomAlgorithm(kCCPRFHmacAlgSHA256),
+                        UInt32(iterations),
+                        &derived,
+                        derived.count
+                    )
+                }
+            }
+        }
+        guard status == kCCSuccess else { throw ConnectionTransferError.keyDerivationFailed }
+        defer { for index in derived.indices { derived[index] = 0 } }
+        return SymmetricKey(data: Data(derived))
+    }
+}

--- a/SSH TunnelBuilder/GUI/AppCommands.swift
+++ b/SSH TunnelBuilder/GUI/AppCommands.swift
@@ -1,0 +1,87 @@
+import SwiftUI
+
+/// App-wide menu commands operating on the shared `ConnectionStore`.
+///
+/// Selection lives in the store (`selectedConnection`), so these commands stay
+/// in sync with the sidebar. Import/export are triggered indirectly: the command
+/// sets `store.transferRequest`, which `ContentView` observes to run the
+/// passphrase prompt and file dialog.
+struct AppCommands: Commands {
+    var store: ConnectionStore
+
+    var body: some Commands {
+        // File ▸ swap the default "New Window" for "New Connection", and add the
+        // import / export items beneath it.
+        CommandGroup(replacing: .newItem) {
+            Button("New Connection") {
+                store.selectedConnection = nil
+                store.mode = .create
+            }
+            .keyboardShortcut("n", modifiers: .command)
+
+            Divider()
+
+            Button("Import Connections…") {
+                store.transferRequest = .importConnections
+            }
+            .keyboardShortcut("i", modifiers: .command)
+
+            Menu("Export") {
+                Button("Export All…") {
+                    store.transferRequest = .exportAll
+                }
+                .disabled(store.connections.isEmpty)
+
+                Button("Export Selected…") {
+                    store.transferRequest = .exportSelected
+                }
+                .disabled(store.selectedConnection == nil)
+            }
+        }
+
+        // Connection ▸ lifecycle plus edit / delete on the current selection.
+        CommandMenu("Connection") {
+            Button("Connect") {
+                if let connection = store.selectedConnection { store.connect(connection) }
+            }
+            .keyboardShortcut("k", modifiers: .command)
+            .disabled(!canConnect)
+
+            Button("Disconnect") {
+                if let connection = store.selectedConnection { store.disconnect(connection) }
+            }
+            .keyboardShortcut("k", modifiers: [.command, .shift])
+            .disabled(!canDisconnect)
+
+            Divider()
+
+            Button("Edit Connection…") {
+                if let connection = store.selectedConnection {
+                    store.updateTempConnection(with: connection)
+                    store.mode = .edit
+                }
+            }
+            .keyboardShortcut("e", modifiers: .command)
+            .disabled(store.selectedConnection == nil)
+
+            Button("Delete Connection") {
+                if let connection = store.selectedConnection {
+                    store.deleteConnection(connection)
+                    store.selectedConnection = nil
+                }
+            }
+            .keyboardShortcut(.delete, modifiers: .command)
+            .disabled(store.selectedConnection == nil)
+        }
+    }
+
+    @MainActor private var canConnect: Bool {
+        guard let connection = store.selectedConnection else { return false }
+        return !connection.isActive && !connection.isConnecting
+    }
+
+    @MainActor private var canDisconnect: Bool {
+        guard let connection = store.selectedConnection else { return false }
+        return connection.isActive || connection.isConnecting
+    }
+}

--- a/SSH TunnelBuilder/GUI/ContentView.swift
+++ b/SSH TunnelBuilder/GUI/ContentView.swift
@@ -31,18 +31,16 @@ struct ContentView: View {
     }
 
     var body: some View {
-        @Bindable var store = connectionStore
-
         NavigationSplitView {
             NavigationList(
                 connectionStore: connectionStore,
-                selectedConnection: $store.selectedConnection,
-                mode: $store.mode
+                selectedConnection: $connectionStore.selectedConnection,
+                mode: $connectionStore.mode
             )
             .environment(connectionStore)
             .accessibilityIdentifier("NavigationList")
         } detail: {
-            MainView(selectedConnection: $store.selectedConnection)
+            MainView(selectedConnection: $connectionStore.selectedConnection)
                 .environment(connectionStore)
                 .accessibilityIdentifier("MainView")
         }
@@ -75,7 +73,7 @@ struct ContentView: View {
         .sheet(isPresented: $showingErrorSheet) {
             ErrorSheetView(message: errorMessage, isPresented: $showingErrorSheet)
         }
-        .alert(item: $store.hostKeyRequest) { request in
+        .alert(item: $connectionStore.hostKeyRequest) { request in
             Alert(
                 title: Text("Unknown Host"),
                 message: Text("The host '\(request.hostname)' is unknown.\n\nFingerprint:\n\(request.fingerprint)\n\nDo you want to trust this host?"),

--- a/SSH TunnelBuilder/GUI/ContentView.swift
+++ b/SSH TunnelBuilder/GUI/ContentView.swift
@@ -1,27 +1,48 @@
 import SwiftUI
 import CoreSpotlight
+import UniformTypeIdentifiers
 
 struct ContentView: View {
     @State private var connectionStore: ConnectionStore
-    @State private var selectedConnection: Connection?
     @State private var showingErrorSheet = false
     @State private var errorMessage = ""
+
+    // MARK: Import / Export flow
+
+    private enum ExportScope: Equatable { case all, selected }
+
+    /// Drives the passphrase sheet. The file dialogs (`isExportingFile` /
+    /// `isImportingFile`) are separate triggers because they run before (import)
+    /// or after (export) the passphrase step, never at the same time.
+    private enum TransferFlow: Equatable {
+        case idle
+        case exportPassphrase(ExportScope)
+        case importPassphrase(Data)
+    }
+
+    @State private var transferFlow: TransferFlow = .idle
+    @State private var exportDocument: EncryptedExportDocument?
+    @State private var isExportingFile = false
+    @State private var isImportingFile = false
+    @State private var suggestedExportName = "SSH Connections"
 
     init(connectionStore: ConnectionStore) {
         _connectionStore = State(initialValue: connectionStore)
     }
 
     var body: some View {
+        @Bindable var store = connectionStore
+
         NavigationSplitView {
             NavigationList(
                 connectionStore: connectionStore,
-                selectedConnection: $selectedConnection,
-                mode: $connectionStore.mode
+                selectedConnection: $store.selectedConnection,
+                mode: $store.mode
             )
             .environment(connectionStore)
             .accessibilityIdentifier("NavigationList")
         } detail: {
-            MainView(selectedConnection: $selectedConnection)
+            MainView(selectedConnection: $store.selectedConnection)
                 .environment(connectionStore)
                 .accessibilityIdentifier("MainView")
         }
@@ -33,7 +54,7 @@ struct ContentView: View {
                 let match = connectionStore.connections.first(where: { $0.id == uuid })
             else { return }
             connectionStore.mode = .view
-            selectedConnection = match
+            connectionStore.selectedConnection = match
         }
         .onChange(of: connectionStore.errorAlert) { _, newValue in
             if let error = newValue {
@@ -46,10 +67,15 @@ struct ContentView: View {
                 }
             }
         }
+        .onChange(of: connectionStore.transferRequest) { _, request in
+            guard let request else { return }
+            connectionStore.transferRequest = nil
+            handleTransferRequest(request)
+        }
         .sheet(isPresented: $showingErrorSheet) {
             ErrorSheetView(message: errorMessage, isPresented: $showingErrorSheet)
         }
-        .alert(item: $connectionStore.hostKeyRequest) { request in
+        .alert(item: $store.hostKeyRequest) { request in
             Alert(
                 title: Text("Unknown Host"),
                 message: Text("The host '\(request.hostname)' is unknown.\n\nFingerprint:\n\(request.fingerprint)\n\nDo you want to trust this host?"),
@@ -61,6 +87,152 @@ struct ContentView: View {
                 }
             )
         }
+        // Each transfer presentation lives on its own hidden host view. macOS
+        // SwiftUI only reliably drives one presentation per view, so stacking the
+        // passphrase sheet and the save/open panels on the same view as the error
+        // sheet + host-key alert caused them to be silently swallowed.
+        .background {
+            Color.clear
+                .sheet(isPresented: passphraseSheetPresented) {
+                    passphraseSheetContent
+                }
+        }
+        .background {
+            Color.clear
+                .fileExporter(
+                    isPresented: $isExportingFile,
+                    document: exportDocument,
+                    contentType: .sshTunnelsExport,
+                    defaultFilename: suggestedExportName
+                ) { result in
+                    if case .failure(let error) = result {
+                        connectionStore.errorAlert = ErrorAlert(message: "Export failed: \(error.localizedDescription)")
+                    }
+                    exportDocument = nil
+                }
+        }
+        .background {
+            Color.clear
+                .fileImporter(
+                    isPresented: $isImportingFile,
+                    allowedContentTypes: [.sshTunnelsExport, .json],
+                    allowsMultipleSelection: false
+                ) { result in
+                    handleImportSelection(result)
+                }
+        }
+    }
+
+    // MARK: - Transfer flow plumbing
+
+    private var passphraseSheetPresented: Binding<Bool> {
+        Binding(
+            get: { transferFlow != .idle },
+            set: { presented in if !presented { transferFlow = .idle } }
+        )
+    }
+
+    @ViewBuilder
+    private var passphraseSheetContent: some View {
+        switch transferFlow {
+        case .exportPassphrase(let scope):
+            PassphrasePromptView(
+                purpose: .encrypt(connectionCount: connections(for: scope).count),
+                onSubmit: { beginEncrypt(scope: scope, passphrase: $0) },
+                onCancel: { transferFlow = .idle }
+            )
+        case .importPassphrase(let data):
+            PassphrasePromptView(
+                purpose: .decrypt,
+                onSubmit: { finishImport(data: data, passphrase: $0) },
+                onCancel: { transferFlow = .idle }
+            )
+        case .idle:
+            EmptyView()
+        }
+    }
+
+    private func connections(for scope: ExportScope) -> [Connection] {
+        switch scope {
+        case .all: return connectionStore.connections
+        case .selected: return [connectionStore.selectedConnection].compactMap { $0 }
+        }
+    }
+
+    private func handleTransferRequest(_ request: ConnectionStore.TransferRequest) {
+        switch request {
+        case .exportAll:
+            guard !connectionStore.connections.isEmpty else {
+                connectionStore.errorAlert = ErrorAlert(message: "There are no connections to export.")
+                return
+            }
+            suggestedExportName = "SSH Connections"
+            transferFlow = .exportPassphrase(.all)
+        case .exportSelected:
+            guard let selected = connectionStore.selectedConnection else {
+                connectionStore.errorAlert = ErrorAlert(message: "Select a connection to export first.")
+                return
+            }
+            let name = selected.connectionInfo.name
+            suggestedExportName = name.isEmpty ? "SSH Connection" : name
+            transferFlow = .exportPassphrase(.selected)
+        case .importConnections:
+            isImportingFile = true
+        }
+    }
+
+    /// Builds the payload (reading secrets from the Keychain on the main actor),
+    /// then encrypts off the main actor — PBKDF2 at 600k iterations is slow.
+    private func beginEncrypt(scope: ExportScope, passphrase: String) {
+        let payload = connectionStore.makeExportPayload(for: connections(for: scope))
+        transferFlow = .idle // dismiss the passphrase sheet before presenting the save panel
+        Task {
+            do {
+                let data = try await Task.detached {
+                    try ConnectionTransfer.encrypt(payload, passphrase: passphrase)
+                }.value
+                exportDocument = EncryptedExportDocument(data: data)
+                isExportingFile = true
+            } catch {
+                connectionStore.errorAlert = ErrorAlert(message: errorText(error))
+            }
+        }
+    }
+
+    private func handleImportSelection(_ result: Result<[URL], Error>) {
+        switch result {
+        case .success(let urls):
+            guard let url = urls.first else { return }
+            // Files chosen via the open panel are security-scoped in the sandbox.
+            let scoped = url.startAccessingSecurityScopedResource()
+            defer { if scoped { url.stopAccessingSecurityScopedResource() } }
+            do {
+                let data = try Data(contentsOf: url)
+                transferFlow = .importPassphrase(data)
+            } catch {
+                connectionStore.errorAlert = ErrorAlert(message: "Couldn’t read the file: \(error.localizedDescription)")
+            }
+        case .failure(let error):
+            connectionStore.errorAlert = ErrorAlert(message: "Import failed: \(error.localizedDescription)")
+        }
+    }
+
+    private func finishImport(data: Data, passphrase: String) {
+        transferFlow = .idle // dismiss the passphrase sheet
+        Task {
+            do {
+                let payload = try await Task.detached {
+                    try ConnectionTransfer.decrypt(data, passphrase: passphrase)
+                }.value
+                connectionStore.importConnections(from: payload)
+            } catch {
+                connectionStore.errorAlert = ErrorAlert(message: errorText(error))
+            }
+        }
+    }
+
+    private func errorText(_ error: Error) -> String {
+        (error as? ConnectionTransferError)?.errorDescription ?? error.localizedDescription
     }
 }
 
@@ -103,4 +275,3 @@ struct ErrorSheetView: View {
 #Preview("With Connections") {
     ContentView(connectionStore: ConnectionStore(mode: .view, connections: SampleData.connections))
 }
-

--- a/SSH TunnelBuilder/GUI/ExportDocument.swift
+++ b/SSH TunnelBuilder/GUI/ExportDocument.swift
@@ -29,7 +29,7 @@ struct EncryptedExportDocument: FileDocument {
         self.data = contents
     }
 
-    func fileWrapper(configuration: WriteConfiguration) throws -> FileWrapper {
+    func fileWrapper(configuration _: WriteConfiguration) throws -> FileWrapper {
         FileWrapper(regularFileWithContents: data)
     }
 }

--- a/SSH TunnelBuilder/GUI/ExportDocument.swift
+++ b/SSH TunnelBuilder/GUI/ExportDocument.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+import UniformTypeIdentifiers
+
+extension UTType {
+    /// Encrypted connection-export file (`.sshtunnels`). Declared in the app's
+    /// `UTExportedTypeDeclarations` Info.plist entry and conforms to `public.json`
+    /// (the on-disk envelope is JSON), so it is both a first-class branded type
+    /// and openable by anything that reads JSON.
+    static let sshTunnelsExport = UTType(exportedAs: "no.comraich.ssh-tunnelbuilder.export")
+}
+
+/// Thin `FileDocument` wrapper used by `.fileExporter`. It carries the already
+/// encrypted bytes produced by `ConnectionTransfer.encrypt` — no plaintext and
+/// no app state, just the blob to write.
+struct EncryptedExportDocument: FileDocument {
+    static var readableContentTypes: [UTType] { [.sshTunnelsExport, .json] }
+    static var writableContentTypes: [UTType] { [.sshTunnelsExport] }
+
+    var data: Data
+
+    init(data: Data) {
+        self.data = data
+    }
+
+    init(configuration: ReadConfiguration) throws {
+        guard let contents = configuration.file.regularFileContents else {
+            throw CocoaError(.fileReadCorruptFile)
+        }
+        self.data = contents
+    }
+
+    func fileWrapper(configuration: WriteConfiguration) throws -> FileWrapper {
+        FileWrapper(regularFileWithContents: data)
+    }
+}

--- a/SSH TunnelBuilder/GUI/PassphrasePromptView.swift
+++ b/SSH TunnelBuilder/GUI/PassphrasePromptView.swift
@@ -1,0 +1,95 @@
+import SwiftUI
+
+/// Collects a passphrase for encrypting an export or decrypting an import.
+///
+/// In `.encrypt` mode it asks for the passphrase twice and requires the two to
+/// match before enabling the action; in `.decrypt` mode it asks once.
+struct PassphrasePromptView: View {
+    enum Purpose {
+        case encrypt(connectionCount: Int)
+        case decrypt
+    }
+
+    let purpose: Purpose
+    let onSubmit: (String) -> Void
+    let onCancel: () -> Void
+
+    @State private var passphrase = ""
+    @State private var confirmation = ""
+
+    private var isEncrypting: Bool {
+        if case .encrypt = purpose { return true }
+        return false
+    }
+
+    private var passphrasesMismatch: Bool {
+        isEncrypting && !confirmation.isEmpty && passphrase != confirmation
+    }
+
+    private var canSubmit: Bool {
+        guard !passphrase.isEmpty else { return false }
+        return isEncrypting ? passphrase == confirmation : true
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Label(title, systemImage: "lock.fill")
+                .font(.headline)
+
+            Text(explanation)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            SecureField("Passphrase", text: $passphrase)
+                .textFieldStyle(.roundedBorder)
+
+            if isEncrypting {
+                SecureField("Confirm passphrase", text: $confirmation)
+                    .textFieldStyle(.roundedBorder)
+
+                if passphrasesMismatch {
+                    Text("Passphrases don’t match.")
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                }
+            }
+
+            HStack {
+                Spacer()
+                Button("Cancel", role: .cancel, action: onCancel)
+                    .keyboardShortcut(.cancelAction)
+                Button(isEncrypting ? "Export" : "Import") {
+                    onSubmit(passphrase)
+                }
+                .keyboardShortcut(.defaultAction)
+                .disabled(!canSubmit)
+                .buttonStyle(.borderedProminent)
+            }
+        }
+        .padding(24)
+        .frame(width: 380)
+    }
+
+    private var title: String {
+        isEncrypting ? "Encrypt Export" : "Open Export"
+    }
+
+    private var explanation: String {
+        switch purpose {
+        case .encrypt(let count):
+            let noun = count == 1 ? "connection" : "connections"
+            return "Choose a passphrase to encrypt \(count) \(noun). You’ll need it to import the file later — it can’t be recovered if lost."
+        case .decrypt:
+            return "Enter the passphrase this file was encrypted with."
+        }
+    }
+}
+
+#Preview("Encrypt") {
+    PassphrasePromptView(purpose: .encrypt(connectionCount: 3), onSubmit: { _ in }, onCancel: {})
+}
+
+#Preview("Decrypt") {
+    PassphrasePromptView(purpose: .decrypt, onSubmit: { _ in }, onCancel: {})
+}

--- a/SSH TunnelBuilder/SSH_TunnelBuilderApp.swift
+++ b/SSH TunnelBuilder/SSH_TunnelBuilderApp.swift
@@ -17,6 +17,9 @@ struct SSH_TunnelBuilderApp: App {
         WindowGroup {
             ContentView(connectionStore: connectionStore)
         }
+        .commands {
+            AppCommands(store: connectionStore)
+        }
 
         Settings {
             SettingsView()

--- a/SSH-TunnelBuilder-Info.plist
+++ b/SSH-TunnelBuilder-Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>UTExportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.json</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>SSH TunnelBuilder Connections</string>
+			<key>UTTypeIdentifier</key>
+			<string>no.comraich.ssh-tunnelbuilder.export</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>sshtunnels</string>
+				</array>
+			</dict>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
Adds encrypted connection import/export, a proper app menu bar, and Xcode Cloud build support. (This branch also carries the earlier `refactor: align UI with Apple SwiftUI guidance` commit.)

### Import / Export
- **`File ▸ Export ▸ Export All… / Export Selected…`** and **`File ▸ Import Connections…`**.
- Encrypted `.sshtunnels` backup: passphrase → **PBKDF2-HMAC-SHA256 (600k)** → **AES-256-GCM**. On-disk is a plaintext JSON envelope (format/version + KDF params) wrapping the ciphertext — **no secrets in cleartext**.
- Full backup incl. secrets: read from / written to the **Keychain** (export may prompt for Touch ID). Imports **mint fresh ids**, so they never overwrite existing CloudKit records.
- Verified live: round-trip, wrong-passphrase rejection, no plaintext leakage, sandbox file dialogs.

### Menu commands
- New `AppCommands`: New Connection (⌘N), Import (⌘I), Export submenu; **Connection** menu — Connect (⌘K), Disconnect (⇧⌘K), Edit (⌘E), Delete (⌘⌫), with correct enable/disable.
- `selectedConnection` hoisted into `ConnectionStore` so commands act on the sidebar selection.

### Xcode Cloud
- Shared scheme committed (`.xcscheme`) + `.gitignore` exception — required for the cloud to build.

### Housekeeping
- Marketing version **2.0 → 2.2**.
- New `.sshtunnels` exported UTI + `ENABLE_USER_SELECTED_FILES` sandbox access.
- Docs added to `CLAUDE.md`.

## Notes
- Built clean (zero warnings); crypto round-trip and the full UI flow exercised in the running app.
- Test suite not run — still blocked by the Swift Testing runner crash on the current beta toolchain (see CLAUDE.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)