### PR TITLE
Credential authentication grace window

### DIFF
--- a/SSH TunnelBuilder/Classes/ConnectionStore.swift
+++ b/SSH TunnelBuilder/Classes/ConnectionStore.swift
@@ -1,6 +1,7 @@
 import Foundation
 import CloudKit
 import Observation
+import LocalAuthentication
 
 private enum CloudKitKeys {
     static let recordType = "Connection"
@@ -95,6 +96,23 @@ class ConnectionStore {
     @ObservationIgnored private var pendingHostKeyDecision: ((Bool) -> Void)?
 
     @ObservationIgnored private var managers: [UUID: SSHManager] = [:]
+
+    // MARK: - Credential authentication grace window
+    //
+    // When "require authentication" is on, the user authenticates once via
+    // `LAContext.evaluatePolicy`; that context is then reused for the Keychain
+    // reads (which therefore don't re-prompt) and kept alive for a short grace
+    // window so reconnects within it need no prompt at all.
+    @ObservationIgnored private var graceContext: LAContext?
+    @ObservationIgnored private var graceExpiry: Date?
+    @ObservationIgnored private var graceExpiryTask: Task<Void, Never>?
+
+    /// How long a single authentication is honoured before the next connect
+    /// re-prompts. Configurable via `UserDefaults`; defaults to 5 minutes.
+    var credentialGraceSeconds: TimeInterval {
+        let stored = UserDefaults.standard.double(forKey: "CredentialGraceSeconds")
+        return stored > 0 ? stored : 300
+    }
 
     /// Credentials storage (Keychain in production, mock for tests)
     private let credentialsStore: CredentialsStore
@@ -261,11 +279,78 @@ class ConnectionStore {
     /// set in memory. A no-op for fields that already carry a value (e.g. typed
     /// into the credentials sheet for this session).
     private func hydrateCredentials(for connection: Connection) {
-        if connection.connectionInfo.password.isEmpty {
-            connection.connectionInfo.password = credentialsStore.loadPassword(for: connection.id) ?? ""
+        let needsPassword = connection.connectionInfo.password.isEmpty
+        let needsPrivateKey = connection.connectionInfo.privateKey.isEmpty
+        // Nothing to read (both already provided this session, or still in memory
+        // from a connect within the grace window) — avoid touching the Keychain.
+        guard needsPassword || needsPrivateKey else { return }
+
+        // Read both secrets reusing the context authenticated up front in
+        // `connect` (see `authenticateForCredentialUse`), so the reads don't
+        // re-prompt. Only fill empty fields, preserving values typed in the sheet.
+        let credentials = credentialsStore.loadCredentials(for: connection.id, authenticatedContext: graceContext)
+        if needsPassword {
+            connection.connectionInfo.password = credentials.password ?? ""
         }
-        if connection.connectionInfo.privateKey.isEmpty {
-            connection.connectionInfo.privateKey = credentialsStore.loadPrivateKey(for: connection.id) ?? ""
+        if needsPrivateKey {
+            connection.connectionInfo.privateKey = credentials.privateKey ?? ""
+        }
+    }
+
+    /// Ensures the user is authenticated to use saved credentials, prompting at
+    /// most once per grace window. Returns `true` when allowed to proceed (always
+    /// true when protection is off or the device can't evaluate a policy).
+    private func authenticateForCredentialUse() async -> Bool {
+        guard isCredentialProtectionEnabled else { return true }
+
+        // Inside an active grace window with a live context: no prompt.
+        if let expiry = graceExpiry, graceContext != nil, expiry > Date() {
+            return true
+        }
+
+        let context = LAContext()
+        context.localizedReason = "Authenticate to use your saved SSH credentials."
+        // Reuse the authentication for the Keychain reads that follow.
+        context.touchIDAuthenticationAllowableReuseDuration = credentialGraceSeconds
+
+        var policyError: NSError?
+        guard context.canEvaluatePolicy(.deviceOwnerAuthentication, error: &policyError) else {
+            // No biometrics / passcode available to evaluate — don't hard-block;
+            // fall back to letting the Keychain reads handle access themselves.
+            Logger.info("Credential auth: policy not evaluable (\(policyError?.localizedDescription ?? "n/a")); proceeding", log: Logger.keychain)
+            return true
+        }
+
+        do {
+            let ok = try await context.evaluatePolicy(.deviceOwnerAuthentication,
+                                                      localizedReason: context.localizedReason)
+            if ok {
+                graceContext = context
+                graceExpiry = Date().addingTimeInterval(credentialGraceSeconds)
+                scheduleGraceExpiry()
+            }
+            return ok
+        } catch {
+            Logger.info("Credential auth cancelled/failed: \(error.localizedDescription)", log: Logger.keychain)
+            return false
+        }
+    }
+
+    /// Schedules clearing of the grace context (and in-memory secrets) when the
+    /// window lapses, so secrets don't linger indefinitely after it expires.
+    private func scheduleGraceExpiry() {
+        graceExpiryTask?.cancel()
+        let seconds = credentialGraceSeconds
+        graceExpiryTask = Task { [weak self] in
+            try? await Task.sleep(for: .seconds(seconds))
+            guard let self, !Task.isCancelled else { return }
+            self.graceContext = nil
+            self.graceExpiry = nil
+            // Drop hydrated secrets from connections that aren't currently active.
+            for connection in self.connections where !connection.isActive {
+                connection.connectionInfo.password = ""
+                connection.connectionInfo.privateKey = ""
+            }
         }
     }
 
@@ -280,31 +365,34 @@ class ConnectionStore {
     /// Initiates an SSH connection for the given connection object
     /// - Parameter connection: The connection to establish
     func connect(_ connection: Connection) {
-        // Load stored secrets just before connecting. They're not kept in the
-        // in-memory model at rest, so this is the point where they're read back —
-        // and, when "require authentication" is on, where the OS prompts for
-        // Touch ID / password. Values already present (e.g. just entered in the
-        // credentials sheet) are left untouched.
-        hydrateCredentials(for: connection)
-
-        let mgr = manager(for: connection)
-
-        // Configure the host key validation handler. It suspends until the user
-        // answers the prompt, then returns their trust decision.
-        mgr.hostKeyValidationHandler = { [weak self] host, fingerprint, _, keyData in
-            guard let self else { return false }
-            return await self.confirmHostKeyTrust(host: host, fingerprint: fingerprint,
-                                                  keyData: keyData, connection: connection)
-        }
-
-        // Configure the error callback to show alerts
-        mgr.errorCallback = { [weak self] errorMsg in
-            Task { @MainActor in
-                self?.showError(errorMsg)
-            }
-        }
-
         Task {
+            // Authenticate once up front (or reuse an active grace window), then
+            // hydrate the secrets from the Keychain reusing that authentication —
+            // so a connect prompts at most once, and reconnects within the grace
+            // window not at all. Bail clearly if the user cancels.
+            guard await authenticateForCredentialUse() else {
+                self.errorAlert = ErrorAlert(message: "Authentication is required to use this connection's saved credentials.")
+                return
+            }
+            hydrateCredentials(for: connection)
+
+            let mgr = manager(for: connection)
+
+            // Configure the host key validation handler. It suspends until the
+            // user answers the prompt, then returns their trust decision.
+            mgr.hostKeyValidationHandler = { [weak self] host, fingerprint, _, keyData in
+                guard let self else { return false }
+                return await self.confirmHostKeyTrust(host: host, fingerprint: fingerprint,
+                                                      keyData: keyData, connection: connection)
+            }
+
+            // Configure the error callback to show alerts
+            mgr.errorCallback = { [weak self] errorMsg in
+                Task { @MainActor in
+                    self?.showError(errorMsg)
+                }
+            }
+
             do {
                 Logger.info("Starting SSH connection for \(connection.connectionInfo.name)", log: Logger.ssh)
                 try await mgr.connect()
@@ -313,27 +401,18 @@ class ConnectionStore {
                 // Show the error - SSHTunnelError provides good localized descriptions
                 let errorMsg = error.localizedDescription
                 Logger.error("SSH connection failed for \(connection.connectionInfo.name): \(errorMsg)", log: Logger.ssh)
-                await MainActor.run {
-                    self.errorAlert = ErrorAlert(message: errorMsg)
-                }
+                self.errorAlert = ErrorAlert(message: errorMsg)
             }
         }
     }
 
-    /// Disconnects an active SSH connection
-    /// - Parameter connection: The connection to disconnect
+    /// Disconnects an active SSH connection. Performs no Keychain access and never
+    /// authenticates — hydrated secrets are cleared when the grace window lapses
+    /// (`scheduleGraceExpiry`), not here, so a quick reconnect stays prompt-free.
     func disconnect(_ connection: Connection) {
         if let mgr = managers[connection.id] {
             Task {
                 await mgr.disconnect()
-                // When credentials are protected, drop the hydrated secrets from
-                // memory after use so the next connect re-authenticates. (When
-                // protection is off we leave them, preserving the prior behaviour
-                // where session-entered credentials survive a reconnect.)
-                if self.isCredentialProtectionEnabled {
-                    connection.connectionInfo.password = ""
-                    connection.connectionInfo.privateKey = ""
-                }
             }
         }
     }

--- a/SSH TunnelBuilder/Classes/ConnectionStore.swift
+++ b/SSH TunnelBuilder/Classes/ConnectionStore.swift
@@ -383,20 +383,11 @@ class ConnectionStore {
 
             let mgr = manager(for: connection)
 
-            // Configure the host key validation handler. It suspends until the
-            // user answers the prompt, then returns their trust decision.
-            mgr.hostKeyValidationHandler = { [weak self] host, fingerprint, _, keyData in
-                guard let self else { return false }
-                return await self.confirmHostKeyTrust(host: host, fingerprint: fingerprint,
-                                                      keyData: keyData, connection: connection)
-            }
-
-            // Configure the error callback to show alerts
-            mgr.errorCallback = { [weak self] errorMsg in
-                Task { @MainActor in
-                    self?.showError(errorMsg)
-                }
-            }
+            // Wire up the host-key and error handlers. Done in a helper method
+            // (not inline) so these `[weak self]` closures — weak to avoid the
+            // store↔manager retain cycle — aren't nested inside this Task's
+            // strong self-capture, which the compiler flags as a mismatch.
+            configureHandlers(for: mgr, connection: connection)
 
             do {
                 Logger.info("Starting SSH connection for \(connection.connectionInfo.name)", log: Logger.ssh)
@@ -407,6 +398,26 @@ class ConnectionStore {
                 let errorMsg = error.localizedDescription
                 Logger.error("SSH connection failed for \(connection.connectionInfo.name): \(errorMsg)", log: Logger.ssh)
                 self.errorAlert = ErrorAlert(message: errorMsg)
+            }
+        }
+    }
+
+    /// Wires the host-key validation and error handlers onto `mgr`. Kept as a
+    /// method so the `[weak self]` capture (which breaks the store↔manager retain
+    /// cycle) isn't nested inside a strong-self-capturing closure.
+    private func configureHandlers(for mgr: SSHManager, connection: Connection) {
+        // Host key validation suspends until the user answers the prompt, then
+        // returns their trust decision.
+        mgr.hostKeyValidationHandler = { [weak self] host, fingerprint, _, keyData in
+            guard let self else { return false }
+            return await self.confirmHostKeyTrust(host: host, fingerprint: fingerprint,
+                                                  keyData: keyData, connection: connection)
+        }
+
+        // Surface SSH errors as alerts.
+        mgr.errorCallback = { [weak self] errorMsg in
+            Task { @MainActor in
+                self?.showError(errorMsg)
             }
         }
     }

--- a/SSH TunnelBuilder/Classes/ConnectionStore.swift
+++ b/SSH TunnelBuilder/Classes/ConnectionStore.swift
@@ -107,11 +107,16 @@ class ConnectionStore {
     @ObservationIgnored private var graceExpiry: Date?
     @ObservationIgnored private var graceExpiryTask: Task<Void, Never>?
 
+    /// `UserDefaults` key backing the grace-window preference (seconds).
+    static let credentialGraceSecondsKey = "CredentialGraceSeconds"
+
     /// How long a single authentication is honoured before the next connect
-    /// re-prompts. Configurable via `UserDefaults`; defaults to 5 minutes.
+    /// re-prompts. Defaults to 5 minutes when unset; an explicit `0` means
+    /// "ask every time".
     var credentialGraceSeconds: TimeInterval {
-        let stored = UserDefaults.standard.double(forKey: "CredentialGraceSeconds")
-        return stored > 0 ? stored : 300
+        let defaults = UserDefaults.standard
+        guard defaults.object(forKey: Self.credentialGraceSecondsKey) != nil else { return 300 }
+        return max(0, defaults.double(forKey: Self.credentialGraceSecondsKey))
     }
 
     /// Credentials storage (Keychain in production, mock for tests)

--- a/SSH TunnelBuilder/Classes/KeychainService.swift
+++ b/SSH TunnelBuilder/Classes/KeychainService.swift
@@ -9,6 +9,15 @@ protocol CredentialsStore {
     func savePrivateKey(_ key: String, for id: UUID)
     func loadPassword(for id: UUID) -> String?
     func loadPrivateKey(for id: UUID) -> String?
+
+    /// Loads both stored secrets for `id` in one call. Pass an `authenticatedContext`
+    /// that the caller has *already* authenticated via `LAContext.evaluatePolicy`
+    /// so these reads reuse that single authentication instead of prompting per
+    /// secret (Keychain-level reuse alone does not suppress per-read prompts).
+    /// Declared on the protocol (not just an extension) so the real Keychain
+    /// implementation is reached through the protocol-typed store.
+    func loadCredentials(for id: UUID, authenticatedContext: LAContext?) -> (password: String?, privateKey: String?)
+
     func deleteCredentials(for id: UUID)
 
     /// Whether a password is stored for `id`, checked *without* reading the
@@ -27,6 +36,13 @@ protocol CredentialsStore {
 
 extension CredentialsStore {
     func setCredentialProtection(enabled: Bool, for ids: [UUID]) {}
+
+    /// Default: read each secret independently. Stores without OS-level
+    /// authentication (e.g. the mock) don't prompt, so the context is ignored.
+    /// `KeychainService` overrides this to read with the authenticated context.
+    func loadCredentials(for id: UUID, authenticatedContext: LAContext?) -> (password: String?, privateKey: String?) {
+        (loadPassword(for: id), loadPrivateKey(for: id))
+    }
 }
 
 // MARK: - Account Keys
@@ -77,6 +93,16 @@ final class KeychainService: CredentialsStore, Sendable {
 
     func loadPrivateKey(for id: UUID) -> String? {
         loadString(account: CredentialAccount.privateKey(for: id), context: makeAuthContext(reason: Self.useReason))
+    }
+
+    func loadCredentials(for id: UUID, authenticatedContext: LAContext?) -> (password: String?, privateKey: String?) {
+        // Reuse the caller's already-authenticated context so neither read
+        // re-prompts. If none is supplied (protection off), a fresh context is
+        // harmless: unprotected items never prompt.
+        let context = authenticatedContext ?? makeAuthContext(reason: Self.useReason)
+        let password = loadString(account: CredentialAccount.password(for: id), context: context)
+        let privateKey = loadString(account: CredentialAccount.privateKey(for: id), context: context)
+        return (password, privateKey)
     }
 
     func deleteCredentials(for id: UUID) {

--- a/SSH TunnelBuilder/GUI/SettingsView.swift
+++ b/SSH TunnelBuilder/GUI/SettingsView.swift
@@ -6,6 +6,7 @@ struct SettingsView: View {
     @Environment(ConnectionStore.self) private var connectionStore
     @AppStorage(SpotlightIndexer.enabledDefaultsKey) private var spotlightEnabled = false
     @AppStorage(KeychainService.protectionEnabledKey) private var requireAuthForCredentials = false
+    @AppStorage(ConnectionStore.credentialGraceSecondsKey) private var credentialGraceSeconds = 300.0
 
     var body: some View {
         Form {
@@ -25,6 +26,20 @@ struct SettingsView: View {
                     .font(.callout)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
+
+                if requireAuthForCredentials {
+                    Picker("Remember authentication", selection: $credentialGraceSeconds) {
+                        Text("Ask every time").tag(0.0)
+                        Text("For 5 minutes").tag(300.0)
+                        Text("For 15 minutes").tag(900.0)
+                        Text("For 30 minutes").tag(1800.0)
+                        Text("For 1 hour").tag(3600.0)
+                    }
+                    Text("How long a single authentication is remembered. Within this window, reconnecting won't ask again.")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
             } header: {
                 Text("Security")
             }


### PR DESCRIPTION
## Summary
Authenticate once per connect for saved credentials, with a configurable grace window so reconnects don't re-prompt, plus a Settings control to tune it.

## Changes
- **Authenticate once per connect** — `connect()` authenticates up front (or reuses an active grace window), then hydrates Keychain secrets reusing that authentication, so a connect prompts at most once and reconnects within the window not at all.
- **Settings control** for the credential-authentication grace window.
- **Warning cleanup** — moved the host-key/error handler setup in `connect()` into a `configureHandlers(for:connection:)` method so the `[weak self]` handlers (which break the store↔manager retain cycle) aren't nested in the `Task`'s strong self-capture. Build is now warning-free.

## Testing
- Builds clean with **zero warnings** (verified via Xcode diagnostics).
- The test suite remains blocked by the known Swift Testing runner crash on the current beta toolchain (unrelated to these changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)