### PR TITLE
feat: allow re-trusting a changed host key

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A SwiftUI app for creating, viewing, editing, and persisting SSH connection prof
 - Securely store passwords and private keys in the Keychain
 - Automatic, one-time migration of secrets from CloudKit to Keychain for older records
 - Password or private-key authentication, including **encrypted (passphrase-protected) keys** — see [Private key authentication](#private-key-authentication)
-- Host-key verification with trust-on-first-use: unknown hosts prompt for confirmation, and the trusted key is pinned for later connections
+- Host-key verification with trust-on-first-use: unknown hosts prompt for confirmation, and the trusted key is pinned for later connections. If a pinned host's key later changes, a clearly-marked "Host Key Changed" prompt lets you re-trust the new key (e.g. after a legitimate server rekey) or cancel (possible MITM).
 - Local port forwarding (DirectTCPIP) to a remote host:port
 - A connection state machine (`idle` → `connecting` → `connected` → `disconnecting`, plus `failed`) driving consistent status UI
 - Live byte counters (sent/received) per connection
@@ -73,12 +73,12 @@ CloudKit Notes:
 - Create: Click the + button, fill in fields, and click "Create".
 - Edit: Select a connection, click the pencil icon, modify fields, and click "Save".
 - Delete: Select a connection and click the trash icon.
-- Connect: Select a connection and click the "Connect" button to establish a tunnel. If no credentials are saved, a sheet prompts for a password and/or private key (with a passphrase field for encrypted keys). The first time you connect to an unknown host, you're asked to confirm its key, which is then pinned for future connections.
+- Connect: Select a connection and click the "Connect" button to establish a tunnel. If no credentials are saved, a sheet prompts for a password and/or private key (with a passphrase field for encrypted keys). The first time you connect to an unknown host, you're asked to confirm its key, which is then pinned for future connections. If the server later presents a different key, a "Host Key Changed" warning surfaces the new fingerprint and lets you re-trust it (the action button is marked destructive) or cancel.
 
 ## Security
 - Passwords and private keys are securely stored in the system Keychain; only non-sensitive metadata is kept in CloudKit.
 - Private-key passphrases are never persisted — they're entered per session and used only in memory.
-- Host keys are verified: unknown hosts require explicit confirmation (trust-on-first-use), and a changed host key for a known host is rejected.
+- Host keys are verified: unknown hosts require explicit confirmation (trust-on-first-use). A changed host key for a known host blocks the connection and triggers a distinct "Host Key Changed" prompt — you must explicitly re-trust the new key (via a destructive-styled action) before the new fingerprint is pinned; cancelling leaves the original pinned key intact.
 - The app includes logic to migrate any credentials previously stored insecurely in CloudKit to the Keychain, after which they are removed from CloudKit.
 - Opt-in Spotlight indexing covers only connection names — never hosts, usernames, ports, or credentials.
 

--- a/SSH TunnelBuilder/Classes/ConnectionStore.swift
+++ b/SSH TunnelBuilder/Classes/ConnectionStore.swift
@@ -30,12 +30,16 @@ struct ErrorAlert: Identifiable, Equatable {
 
 // MARK: - Structure to hold host key verification details for UI
 
-/// Represents a host key validation request that requires user confirmation
+/// Represents a host key validation request that requires user confirmation.
+/// `isMismatch` distinguishes a first-use trust prompt from a re-trust prompt
+/// triggered by a changed host key — the UI presents a stronger warning in the
+/// latter case (possible MITM, or a deliberate server rekey).
 struct HostKeyRequest: Identifiable {
     let id = UUID()
     let hostname: String
     let fingerprint: String
     let keyData: Data
+    let isMismatch: Bool
     let completion: (Bool) -> Void
 }
 
@@ -248,11 +252,13 @@ class ConnectionStore {
         errorAlert = ErrorAlert(message: message)
     }
 
-    /// Presents the unknown-host prompt and suspends until the user answers.
-    /// On trust, records the key on the connection and persists it.
+    /// Presents the unknown-host (or changed-host) prompt and suspends until the
+    /// user answers. On trust, records the key on the connection and persists it,
+    /// replacing any previously pinned key when this is a mismatch re-trust.
     /// - Returns: `true` if the user trusts the host, `false` otherwise.
     private func confirmHostKeyTrust(host: String, fingerprint: String,
-                                     keyData: Data, connection: Connection) async -> Bool {
+                                     keyData: Data, isMismatch: Bool,
+                                     connection: Connection) async -> Bool {
         // If a prior prompt is still awaiting an answer, deny it before replacing
         // it so its awaiting Task can't leak.
         pendingHostKeyDecision?(false)
@@ -269,11 +275,13 @@ class ConnectionStore {
             }
             pendingHostKeyDecision = decide
             hostKeyRequest = HostKeyRequest(hostname: host, fingerprint: fingerprint,
-                                            keyData: keyData, completion: decide)
+                                            keyData: keyData, isMismatch: isMismatch,
+                                            completion: decide)
         }
 
         if trusted {
             // Record the now-trusted key on the connection and persist to CloudKit.
+            // On a mismatch re-trust this overwrites the previously pinned key.
             connection.connectionInfo.knownHostKey = keyData.base64EncodedString()
             saveConnection(connection, connectionToUpdate: connection)
         }
@@ -408,10 +416,11 @@ class ConnectionStore {
     private func configureHandlers(for mgr: SSHManager, connection: Connection) {
         // Host key validation suspends until the user answers the prompt, then
         // returns their trust decision.
-        mgr.hostKeyValidationHandler = { [weak self] host, fingerprint, _, keyData in
+        mgr.hostKeyValidationHandler = { [weak self] host, fingerprint, _, keyData, isMismatch in
             guard let self else { return false }
             return await self.confirmHostKeyTrust(host: host, fingerprint: fingerprint,
-                                                  keyData: keyData, connection: connection)
+                                                  keyData: keyData, isMismatch: isMismatch,
+                                                  connection: connection)
         }
 
         // Surface SSH errors as alerts.

--- a/SSH TunnelBuilder/Classes/SSHManager.swift
+++ b/SSH TunnelBuilder/Classes/SSHManager.swift
@@ -40,8 +40,10 @@ final class SSHManager: @unchecked Sendable {
     /// runs past `handshakeTimeoutSeconds`. Guarded by `lock`.
     private var handshakeTimeoutTask: Scheduled<Void>?
 
-    // Async handler: (hostname, fingerprint, keyType, keyData) -> user's trust decision
-    var hostKeyValidationHandler: (@Sendable (String, String, String, Data) async -> Bool)?
+    // Async handler: (hostname, fingerprint, keyType, keyData, isMismatch) -> user's trust decision.
+    // `isMismatch` is true when a previously pinned key exists but no longer matches — the UI should
+    // present a stronger warning so the user can replace the pinned key knowingly.
+    var hostKeyValidationHandler: (@Sendable (String, String, String, Data, Bool) async -> Bool)?
 
     /// Callback invoked when an error occurs that should be shown to the user
     var errorCallback: (@Sendable (String) -> Void)?
@@ -211,6 +213,7 @@ final class SSHManager: @unchecked Sendable {
             fingerprint = "SHA256:UNAVAILABLE"
         }
 
+        var isMismatch = false
         if !knownHostKey.isEmpty {
             // Try raw key base64 match first (if we have raw key bytes)
             if let keyData = keyData, let knownData = Data(base64Encoded: knownHostKey), knownData == keyData {
@@ -222,12 +225,15 @@ final class SSHManager: @unchecked Sendable {
                 promise.succeed(())
                 return
             }
-            promise.fail(SSHTunnelError.hostKeyMismatch)
-            return
+            // A previously pinned key is on file but doesn't match what the server
+            // just presented. Don't auto-fail — surface the change to the user so
+            // they can re-trust the new key (e.g. after a legitimate server rekey)
+            // or reject it (possible MITM).
+            isMismatch = true
         }
 
         guard let handler = self.hostKeyValidationHandler else {
-            promise.fail(SSHTunnelError.hostKeyValidationMissing)
+            promise.fail(isMismatch ? SSHTunnelError.hostKeyMismatch : SSHTunnelError.hostKeyValidationMissing)
             return
         }
 
@@ -243,12 +249,12 @@ final class SSHManager: @unchecked Sendable {
             // against the handshake deadline. Re-arm once they trust so the
             // remaining auth phase stays bounded.
             self.cancelHandshakeTimeout()
-            let allowed = await handler(host, fingerprint, keyType, resolvedKeyData)
+            let allowed = await handler(host, fingerprint, keyType, resolvedKeyData, isMismatch)
             if allowed {
                 self.armHandshakeTimeout()
                 promise.succeed(())
             } else {
-                promise.fail(SSHTunnelError.hostKeyRejected)
+                promise.fail(isMismatch ? SSHTunnelError.hostKeyMismatch : SSHTunnelError.hostKeyRejected)
             }
         }
     }

--- a/SSH TunnelBuilder/GUI/ContentView.swift
+++ b/SSH TunnelBuilder/GUI/ContentView.swift
@@ -74,7 +74,22 @@ struct ContentView: View {
             ErrorSheetView(message: errorMessage, isPresented: $showingErrorSheet)
         }
         .alert(item: $connectionStore.hostKeyRequest) { request in
-            Alert(
+            if request.isMismatch {
+                // Re-trust prompt: the previously pinned key no longer matches.
+                // Use a destructive primary button so the user has to deliberately
+                // overwrite the pinned key — this path could otherwise mask a MITM.
+                return Alert(
+                    title: Text("Host Key Changed"),
+                    message: Text("The host key for '\(request.hostname)' has changed since it was last trusted.\n\nNew fingerprint:\n\(request.fingerprint)\n\nThis can happen if the server was reinstalled or rekeyed — or it could indicate a man-in-the-middle attack. Only trust the new key if you are sure it is legitimate."),
+                    primaryButton: .destructive(Text("Trust New Key")) {
+                        request.completion(true)
+                    },
+                    secondaryButton: .cancel(Text("Cancel")) {
+                        request.completion(false)
+                    }
+                )
+            }
+            return Alert(
                 title: Text("Unknown Host"),
                 message: Text("The host '\(request.hostname)' is unknown.\n\nFingerprint:\n\(request.fingerprint)\n\nDo you want to trust this host?"),
                 primaryButton: .default(Text("Trust")) {


### PR DESCRIPTION
## Summary
- A mismatch between the server's host key and the pinned key used to fail the connection with `.hostKeyMismatch` and no UI recovery — the user had to edit CloudKit by hand. The validation path now forks: first-use still shows the existing "Unknown Host" prompt; a mismatch routes through the same handler with `isMismatch: true` and surfaces a distinct "Host Key Changed" alert with a destructive primary button and an explicit MITM warning. Trusting overwrites the pinned key via the existing save path; cancelling leaves it intact and still fails with `.hostKeyMismatch`.
- `SSHManager.hostKeyValidationHandler` gains an `isMismatch: Bool` parameter; `ConnectionStore.HostKeyRequest` / `confirmHostKeyTrust` propagate it; `ContentView`'s alert branches on it.
- `README.md` updated in the Features, Usage → Connect, and Security sections to describe the new re-trust flow.

## Test plan
- [ ] Manual: connect to a host whose pinned key has been changed server-side (e.g. regenerate `/etc/ssh/ssh_host_*` keys), confirm the "Host Key Changed" alert appears with the new fingerprint and a red destructive "Trust New Key" button.
- [ ] Manual: choose **Cancel** — connection fails with `hostKeyMismatch`; reconnect still surfaces the same prompt (pinned key untouched).
- [ ] Manual: choose **Trust New Key** — connection proceeds; next reconnect succeeds without prompting (new key now pinned, round-tripped to CloudKit).
- [ ] Manual: first connection to a brand-new host still shows the original "Unknown Host" prompt (default-styled "Trust" button), unchanged.
- [x] Build: project builds clean (warnings-free) on the current toolchain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)