### PR TITLE
fix: collapse credential prompts to once per grace window

### DIFF
--- a/SSH TunnelBuilder/Classes/ConnectionStore.swift
+++ b/SSH TunnelBuilder/Classes/ConnectionStore.swift
@@ -448,9 +448,15 @@ class ConnectionStore {
         UserDefaults.standard.bool(forKey: KeychainService.protectionEnabledKey)
     }
 
-    /// Re-keys all stored credentials to match the new protection preference.
-    /// The preference itself is written by the Settings toggle (`@AppStorage`)
-    /// before this runs; here we just bring existing Keychain items in line.
+    /// Migrates any pre-existing `.userPresence`-protected Keychain items to the
+    /// new unprotected form (gated only by the app-side `evaluatePolicy` check
+    /// in `authenticateForCredentialUse()`). Items already stored without
+    /// access control just round-trip a re-save. Called when the user toggles
+    /// the Settings preference so a freshly-enabled "require authentication"
+    /// state immediately gives them the single-prompt-per-grace-window
+    /// behaviour, even if their old items still carried the legacy flag.
+    /// The `enabled` value is forwarded for API symmetry but no longer changes
+    /// how items are stored.
     func reprotectStoredCredentials(enabled: Bool) {
         credentialsStore.setCredentialProtection(enabled: enabled, for: connections.map(\.id))
     }

--- a/SSH TunnelBuilder/Classes/KeychainService.swift
+++ b/SSH TunnelBuilder/Classes/KeychainService.swift
@@ -64,17 +64,14 @@ final class KeychainService: CredentialsStore, Sendable {
 
     /// `UserDefaults` key backing the "require Touch ID / password to use saved
     /// credentials" setting. Shared with the `@AppStorage` binding in Settings.
+    /// The toggle is enforced *app-side* by `ConnectionStore.authenticateForCredentialUse()`
+    /// — Keychain items themselves are no longer gated with `.userPresence`
+    /// because that flag prompts on every read regardless of `LAContext` state,
+    /// which defeats the single-prompt-per-grace-window model the user expects.
     static let protectionEnabledKey = "RequireAuthForStoredCredentials"
 
-    /// Whether stored credentials should be protected by user-presence
-    /// (Touch ID / password). Read fresh on each save so a toggle takes effect
-    /// immediately for subsequently re-keyed items.
-    private var isProtectionEnabled: Bool {
-        UserDefaults.standard.bool(forKey: Self.protectionEnabledKey)
-    }
-
     /// Default prompt shown when the OS asks the user to authenticate before a
-    /// protected credential is read.
+    /// legacy `.userPresence`-protected credential is read during lazy migration.
     private static let useReason = "Authenticate to use your saved SSH credentials."
 
     // MARK: - Public API
@@ -118,16 +115,22 @@ final class KeychainService: CredentialsStore, Sendable {
         containsItem(account: CredentialAccount.privateKey(for: id))
     }
 
-    /// Re-saves every stored secret so its Keychain protection matches the
-    /// current `isProtectionEnabled` preference. A single `LAContext` is reused
-    /// across the batch so disabling protection (which must *read* the currently
-    /// protected items) prompts the user only once.
+    /// Reads each stored secret and re-saves it without the legacy `.userPresence`
+    /// access control flag, using a single reusable `LAContext` so the migration
+    /// authenticates at most once. After this runs every item is gated solely by
+    /// the app-side `evaluatePolicy` check in `ConnectionStore`, which means a
+    /// single Touch ID per grace window covers every connect/edit/export. Safe
+    /// to call repeatedly: items already saved without access control just
+    /// round-trip a re-save (cheap, idempotent).
+    ///
+    /// The `enabled` parameter is accepted for source compatibility with the
+    /// old toggle-driven re-key call site but no longer affects how items are
+    /// stored — they are always stored without `.userPresence`.
     func setCredentialProtection(enabled: Bool, for ids: [UUID]) {
-        let reason = enabled
-            ? "Authenticate to protect your saved SSH credentials with Touch ID or your password."
-            : "Authenticate to remove Touch ID / password protection from your saved SSH credentials."
-        // One reusable context so the whole re-key pass authenticates at most once.
-        let context = makeAuthContext(reason: reason, reuseDuration: 30)
+        let context = makeAuthContext(
+            reason: "Authenticate to unlock your saved SSH credentials.",
+            reuseDuration: 30
+        )
 
         for id in ids {
             let pwAccount = CredentialAccount.password(for: id)
@@ -159,45 +162,24 @@ final class KeychainService: CredentialsStore, Sendable {
 
     private func saveString(_ string: String, account: String) {
         guard let data = string.data(using: .utf8) else { return }
-        // Delete existing item first to avoid duplicates
+        // Delete existing item first to avoid duplicates and to strip any legacy
+        // `.userPresence` access-control attribute the item may have carried.
         deleteItem(account: account)
 
-        var query: [String: Any] = [
+        let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
             kSecAttrAccount as String: account,
-            kSecValueData as String: data
+            kSecValueData as String: data,
+            // Items stay on this Mac and require login (no `.userPresence`):
+            // the app-side `evaluatePolicy` gate in `ConnectionStore` is what
+            // governs the Touch ID prompt, honoured once per grace window.
+            kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlockedThisDeviceOnly
         ]
-        // When protection is enabled, gate reads behind user presence
-        // (Touch ID / password). `kSecAttrAccessControl` and `kSecAttrAccessible`
-        // are mutually exclusive, so set exactly one.
-        if isProtectionEnabled, let accessControl = makeUserPresenceAccessControl() {
-            query[kSecAttrAccessControl as String] = accessControl
-        } else {
-            query[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
-        }
         let status = SecItemAdd(query as CFDictionary, nil)
         if status != errSecSuccess {
             Logger.error("Failed to save item for account '\(account)'. OSStatus: \(status)", log: Logger.keychain)
         }
-    }
-
-    /// Builds a user-presence access-control object: the item can only be read
-    /// after the user authenticates with Touch ID or their login password
-    /// (`.userPresence`), and never leaves this device.
-    private func makeUserPresenceAccessControl() -> SecAccessControl? {
-        var error: Unmanaged<CFError>?
-        let accessControl = SecAccessControlCreateWithFlags(
-            nil,
-            kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
-            .userPresence,
-            &error
-        )
-        if let error = error?.takeRetainedValue() {
-            Logger.error("Failed to create Keychain access control: \(error)", log: Logger.keychain)
-            return nil
-        }
-        return accessControl
     }
 
     /// Builds an `LAContext` carrying the prompt text shown when the OS asks the
@@ -211,23 +193,36 @@ final class KeychainService: CredentialsStore, Sendable {
         return context
     }
 
-    /// Reads a stored string. For access-control-protected items the OS presents
-    /// an authentication prompt (using `context.localizedReason`); a shared
-    /// `context` lets a batch authenticate once. Unprotected items never prompt.
+    /// Reads a stored string. New items have no access-control flag so reads are
+    /// silent. Legacy items saved under the previous `.userPresence` regime
+    /// prompt the OS on read; on first successful read we transparently re-save
+    /// them without the flag (lazy migration) so subsequent reads are silent.
     private func loadString(account: String, context: LAContext? = nil) -> String? {
         var query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
             kSecAttrAccount as String: account,
             kSecReturnData as String: true,
+            kSecReturnAttributes as String: true,
             kSecMatchLimit as String: kSecMatchLimitOne
         ]
         if let context { query[kSecUseAuthenticationContext as String] = context }
 
         var item: CFTypeRef?
         let status = SecItemCopyMatching(query as CFDictionary, &item)
-        guard status == errSecSuccess, let data = item as? Data else { return nil }
-        return String(data: data, encoding: .utf8)
+        guard status == errSecSuccess,
+              let dict = item as? [String: Any],
+              let data = dict[kSecValueData as String] as? Data,
+              let value = String(data: data, encoding: .utf8) else { return nil }
+
+        // Lazy migration: items with `kSecAttrAccessControl` present in their
+        // returned attributes are legacy `.userPresence`-protected items. Re-save
+        // them without the flag now that we've successfully read the plaintext,
+        // so future reads no longer trigger per-item OS prompts.
+        if dict[kSecAttrAccessControl as String] != nil {
+            saveString(value, account: account)
+        }
+        return value
     }
 
     private func deleteItem(account: String) {

--- a/SSH TunnelBuilder/GUI/SettingsView.swift
+++ b/SSH TunnelBuilder/GUI/SettingsView.swift
@@ -22,7 +22,7 @@ struct SettingsView: View {
 
             Section {
                 Toggle("Require Touch ID or password to use saved credentials", isOn: $requireAuthForCredentials)
-                Text("When enabled, your saved passwords and private keys are stored so that connecting (or editing a connection) requires Touch ID or your login password. This adds a layer of protection if someone gains access to your unlocked Mac, at the cost of an authentication prompt each time you connect.")
+                Text("When enabled, using a saved password or private key requires a single Touch ID / login-password prompt per session — connecting, editing, and exporting are all covered by the same authentication for the duration of the grace window below. Your secrets stay on this Mac and never leave the Keychain.")
                     .font(.callout)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
@@ -56,10 +56,11 @@ struct SettingsView: View {
             }
         }
         .onChange(of: requireAuthForCredentials) { _, isOn in
-            // The preference (read by KeychainService when saving) is already
-            // updated by @AppStorage; re-key the existing stored credentials so
-            // the new protection applies to them too. Disabling prompts once to
-            // read the currently protected items.
+            // The toggle now governs *only* the app-side `evaluatePolicy` gate
+            // — Keychain items are no longer stamped with `.userPresence`. We
+            // still run a one-pass migration so any pre-existing protected
+            // items from older app versions are re-saved without the flag, so
+            // future connects honour the single-prompt-per-grace-window model.
             connectionStore.reprotectStoredCredentials(enabled: isOn)
         }
     }


### PR DESCRIPTION
## Summary
- Root cause: Keychain items were stamped with `.userPresence` access control whenever **Require authentication** was on. `.userPresence` re-checks user presence on *every* `SecItemCopyMatching`, regardless of the authenticated `LAContext` passed via `kSecUseAuthenticationContext` — so the app-side grace window in `ConnectionStore` couldn't actually suppress prompts. Real-world impact: 4–5 Touch ID prompts on first connect, 4 on subsequent connects, plus "random" prompts on edit/export.
- Fix: drop `.userPresence` from new Keychain saves entirely (`KeychainService.saveString` now uses only `kSecAttrAccessibleWhenUnlockedThisDeviceOnly`). Authentication is enforced exclusively by `ConnectionStore.authenticateForCredentialUse()` — one `evaluatePolicy` prompt per grace window covers every connect, edit, and export until the window lapses.
- Lazy migration: `loadString` now requests attributes alongside data and re-saves any item whose returned attributes still carry `kSecAttrAccessControl`, transparently stripping the legacy flag the first time each item is read post-upgrade.
- `setCredentialProtection(enabled:)` is kept as a forward-compatible migration vehicle invoked when the user toggles the Settings preference, so existing protected items are scrubbed even if a user never reconnects an old connection. The `enabled` value is accepted for source compatibility but no longer changes how items are stored.
- Settings copy updated to reflect the new single-prompt-per-grace-window semantics.

## Trade-off (documented in the comments)
Keychain items remain `kSecAttrAccessibleWhenUnlockedThisDeviceOnly` (login required, device-only, no iCloud Keychain sync), and the **Require authentication** gate still demands a prompt at the start of each grace window. The change is that *within* a grace window, repeated credential access is silent — matching the existing user-facing description of the grace window.

## Test plan
- [x] Build clean.
- [ ] Manual: with **Require authentication** ON, grace window > 0, connect to a connection — expect exactly **one** Touch ID prompt (from `evaluatePolicy`), not 4–5. The first connect after upgrading may still produce extra prompts as legacy `.userPresence` items are read once for the lazy migration; the second connect should be single-prompt.
- [ ] Manual: editing a connection or running an export within the grace window should not re-prompt.
- [ ] Manual: after the grace window expires, the next connect re-prompts once.
- [ ] Manual: toggling **Require authentication** off → on (or vice versa) in Settings runs the migration pass; subsequent connects honour the new single-prompt model.
- [ ] Manual: with **Require authentication** OFF, no prompts at any point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)