### PR TITLE
fix: keep sidebar Delete button out of the toolbar overflow

### DIFF
--- a/SSH TunnelBuilder/GUI/NavigationView.swift
+++ b/SSH TunnelBuilder/GUI/NavigationView.swift
@@ -18,39 +18,47 @@ struct NavigationList: View {
             }
         }
         .listStyle(.sidebar)
-        .frame(minWidth: 230)
+        // Default the sidebar to a width that comfortably fits the window
+        // controls plus all three primary toolbar buttons (Create / Edit /
+        // Delete). Without this, macOS pushes the trailing items — Delete
+        // first — into the "···" overflow menu at the default split width.
+        .navigationSplitViewColumnWidth(min: 230, ideal: 300, max: 500)
         .navigationTitle("Navigation")
+        // Use `.primaryAction` rather than `.automatic` so macOS keeps Create /
+        // Edit / Delete visible side-by-side instead of pushing the trailing
+        // items (Delete first) into the "···" overflow when the sidebar is
+        // narrow.
         .toolbar {
-            ToolbarItem(placement: .automatic) {
-                Button(action: {
+            ToolbarItem(placement: .primaryAction) {
+                Button {
                     connectionStore.mode = .create
                     selectedConnection = nil
-                }) {
+                } label: {
                     Label("Create new connection", systemImage: "plus")
                 }
                 .help("Create new connection")
             }
-            
-            ToolbarItem(placement: .automatic) {
-                if selectedConnection != nil {
-                    Button(action: {
+
+            if selectedConnection != nil {
+                ToolbarItem(placement: .primaryAction) {
+                    Button {
                         mode = .edit
                         if let connection = selectedConnection {
                             connectionStore.updateTempConnection(with: connection)
                         }
-                    }) {
+                    } label: {
                         Label("Edit selected connection", systemImage: "pencil")
                     }
                     .help("Edit selected connection")
                 }
             }
-            
-            ToolbarItem(placement: .automatic) {
-                if let connection = selectedConnection {
-                    Button(action: {
+
+            if let connection = selectedConnection {
+                ToolbarItem(placement: .primaryAction) {
+                    Button(role: .destructive) {
                         connectionStore.deleteConnection(connection)
                         selectedConnection = nil
-                    }) {
+                    } label: {
                         Label("Delete selected connection", systemImage: "trash")
                     }
                     .help("Delete selected connection")


### PR DESCRIPTION
## Summary
- At the default sidebar width macOS pushed the trailing toolbar item — **Delete** — into the "···" overflow menu, hiding the destructive action.
- Pin Create / Edit / Delete with `placement: .primaryAction` instead of `.automatic`, so macOS keeps them in the visible toolbar region instead of collapsing the rightmost item.
- Wrap the conditional Edit / Delete items so the `if` covers the whole `ToolbarItem`, avoiding an empty slot when nothing is selected; Delete is now `role: .destructive` for the standard red treatment.
- Replace `.frame(minWidth: 230)` with `.navigationSplitViewColumnWidth(min: 230, ideal: 300, max: 500)` so the sidebar defaults wide enough to fit the window controls plus all three buttons. Lower bound matches the previous minimum; users can still resize within the new range.

## Note on existing windows
macOS persists window/sidebar state per app. If an existing window restores at the old narrow width, Delete may still overflow on first launch — dragging the splitter wider once will stick; new installs / fresh windows get the 300pt ideal width straight away.

## Test plan
- [x] Build clean.
- [ ] Manual: launch the app at default window size — sidebar shows Create + Edit (when a row is selected) + Delete (when a row is selected) all visible, no "···" overflow.
- [ ] Manual: drag the splitter narrower than the 230 minimum — splitter respects the floor; drag wider than 500 — splitter respects the ceiling.
- [ ] Manual: select a row, click Delete — Delete shows the standard red destructive treatment, and clicking it deletes the connection as before.
- [ ] Manual: deselect — Edit and Delete toolbar slots disappear cleanly (no empty button-shaped gap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)