### PR TITLE
harden: pre-App-Store defense-in-depth pass

### DIFF
--- a/SSH TunnelBuilder/Classes/ConnectionStore.swift
+++ b/SSH TunnelBuilder/Classes/ConnectionStore.swift
@@ -853,6 +853,12 @@ class ConnectionStore {
     @discardableResult
     func importConnections(from payload: ExportPayload) -> Int {
         for item in payload.connections {
+            // Discard any host-key pin from the import. A pinned `knownHostKey`
+            // short-circuits the TOFU prompt on first connect, so honouring one
+            // from an untrusted bundle would let the bundle author silently
+            // pre-pin a key they control. Forcing it empty here makes the user
+            // see and confirm the real server fingerprint on first connect to
+            // each imported host.
             let connectionInfo = ConnectionInfo(
                 name: item.name,
                 serverAddress: item.serverAddress,
@@ -861,7 +867,7 @@ class ConnectionStore {
                 password: item.password,
                 privateKey: item.privateKey,
                 privateKeyPassphrase: item.privateKeyPassphrase,
-                knownHostKey: item.knownHostKey
+                knownHostKey: ""
             )
             let tunnelInfo = TunnelInfo(
                 localPort: item.localPort,

--- a/SSH TunnelBuilder/Classes/ConnectionTransfer.swift
+++ b/SSH TunnelBuilder/Classes/ConnectionTransfer.swift
@@ -92,6 +92,13 @@ enum ConnectionTransfer {
     private static let saltByteCount = 16
     private static let keyByteCount = 32 // AES-256
 
+    /// Bounds for envelope-supplied KDF parameters. Files outside this range are
+    /// treated as malformed before the (slow) key-derivation step runs — both to
+    /// avoid a `UInt32(...)` overflow trap on a hostile `iterations` field and to
+    /// reject obviously-broken salt lengths that no honest exporter would write.
+    private static let iterationsRange = 100_000...10_000_000
+    private static let saltLengthRange = 8...64
+
     /// Encrypts `payload` under `passphrase`, returning the bytes to write to disk.
     static func encrypt(_ payload: ExportPayload, passphrase: String) throws -> Data {
         guard !passphrase.isEmpty else { throw ConnectionTransferError.emptyPassphrase }
@@ -146,6 +153,12 @@ enum ConnectionTransfer {
             let combined = Data(base64Encoded: envelope.data)
         else {
             throw ConnectionTransferError.malformed("invalid base64")
+        }
+        guard iterationsRange.contains(envelope.iterations) else {
+            throw ConnectionTransferError.malformed("iterations out of range")
+        }
+        guard saltLengthRange.contains(salt.count) else {
+            throw ConnectionTransferError.malformed("salt length out of range")
         }
 
         let key = try deriveKey(passphrase: passphrase, salt: salt, iterations: envelope.iterations)

--- a/SSH TunnelBuilder/Classes/Logger.swift
+++ b/SSH TunnelBuilder/Classes/Logger.swift
@@ -19,15 +19,23 @@ enum Logger {
 
     // MARK: - Convenience Methods
 
+    // The os.log default privacy level (`.private`) shows full values to a
+    // developer attached via Xcode but redacts them to `<private>` in archived
+    // logs (sysdiagnose, Console.app on another user account, support bundles).
+    // Most call sites interpolate hostnames, tunnel targets, or connection
+    // nicknames — operational metadata that shouldn't ship verbatim in
+    // diagnostics. Keep that default; let individual call sites opt into
+    // `privacy: .public` where they explicitly want a public correlator.
+
     static func debug(_ message: String, log: Category) {
-        log.logger.debug("\(message, privacy: .public)")
+        log.logger.debug("\(message)")
     }
 
     static func info(_ message: String, log: Category) {
-        log.logger.info("\(message, privacy: .public)")
+        log.logger.info("\(message)")
     }
 
     static func error(_ message: String, log: Category) {
-        log.logger.error("\(message, privacy: .public)")
+        log.logger.error("\(message)")
     }
 }

--- a/SSH TunnelBuilder/Classes/PEMDecryptor.swift
+++ b/SSH TunnelBuilder/Classes/PEMDecryptor.swift
@@ -367,7 +367,7 @@ private struct ASN1Parser {
         guard offset + length <= data.count else {
             throw PEMDecryptorError.asn1ParseError("ANY length exceeds data")
         }
-        let anyData = data[(offset-2-length)..<(offset+length)]
+        let anyData = data[offset..<(offset + length)]
         offset += length
         return try ASN1Parser(data: anyData)
     }

--- a/SSH TunnelBuilder/Classes/SSHManager.swift
+++ b/SSH TunnelBuilder/Classes/SSHManager.swift
@@ -215,20 +215,25 @@ final class SSHManager: @unchecked Sendable {
 
         var isMismatch = false
         if !knownHostKey.isEmpty {
-            // Try raw key base64 match first (if we have raw key bytes)
-            if let keyData = keyData, let knownData = Data(base64Encoded: knownHostKey), knownData == keyData {
-                promise.succeed(())
-                return
-            }
-            // Then try fingerprint match (stored as the literal SHA256:... string)
-            if knownHostKey == fingerprint {
-                promise.succeed(())
-                return
+            // Only consider a stored pin authoritative when we actually have wire
+            // bytes for the presented key. If `serialize(key:)` returned nil, the
+            // fingerprint is the non-host-specific "SHA256:UNAVAILABLE" sentinel;
+            // matching against it would silently trust any host that triggers the
+            // nil-serialize path, so we force the user to re-confirm instead.
+            if let keyData = keyData {
+                if let knownData = Data(base64Encoded: knownHostKey), knownData == keyData {
+                    promise.succeed(())
+                    return
+                }
+                if knownHostKey == fingerprint {
+                    promise.succeed(())
+                    return
+                }
             }
             // A previously pinned key is on file but doesn't match what the server
-            // just presented. Don't auto-fail — surface the change to the user so
-            // they can re-trust the new key (e.g. after a legitimate server rekey)
-            // or reject it (possible MITM).
+            // just presented (or we can't verify it). Don't auto-fail — surface the
+            // change to the user so they can re-trust the new key (e.g. after a
+            // legitimate server rekey) or reject it (possible MITM).
             isMismatch = true
         }
 

--- a/security_hardening.md
+++ b/security_hardening.md
@@ -1,0 +1,119 @@
+# Security Hardening — Pre-App-Store
+
+Five items surfaced by the 2026-06-17 whole-app security audit. None rose to a
+reportable vulnerability under a strict false-positive filter, but each is a
+defense-in-depth fix worth landing before submission. They are independent and
+can be implemented in any order.
+
+---
+
+## 1. ASN.1 parser slice underflow
+
+**File:** `SSH TunnelBuilder/Classes/PEMDecryptor.swift:370`
+
+`ASN1Parser.readAny()` computes its returned slice as
+`data[(offset-2-length)..<(offset+length)]`. The lower bound subtracts `length`
+a second time, so any value where `length > offset - 2` produces a negative
+`Data.Index` and Swift's bounds-checked subscript traps the process. Reachable
+from `decryptEncryptedPKCS8PEM` via:
+
+- the PBES2/PBKDF2 PRF `parameters` field (`PEMDecryptor.swift:62`)
+- the trailing-data drain on `PrivateKeyInfo` (`PEMDecryptor.swift:103`)
+
+Both call sites discard the returned parser (`_ = try? prfAlg.readAny()`), so the
+fix is to slice only the value bytes and match the existing `readOID` /
+`readInteger` pattern.
+
+**Fix:** replace the slice expression at line 370 with
+`data[offset..<(offset + length)]`. Wrap in `Data(...)` if the call sites ever
+re-enter `ASN1Parser` on the result (the previously-fixed parent-slice indexing
+bug applies here too).
+
+## 2. KDF iteration count clamping
+
+**File:** `SSH TunnelBuilder/Classes/ConnectionTransfer.swift:198`
+
+`UInt32(envelope.iterations)` traps on negative values or values exceeding
+`UInt32.max`. The iteration count is taken from the on-disk envelope before any
+authentication runs, so a crafted `.sshtunnels` file deterministically crashes
+the importer the moment the user provides a passphrase.
+
+This is DoS-only (the importer doesn't expose anything to the attacker on
+crash), but it's a one-line guard that prevents a hard-crash on a user-initiated
+operation.
+
+**Fix:** validate `envelope.iterations` against a sane range
+(`100_000…10_000_000`) in `ConnectionTransfer.decrypt` and throw
+`ConnectionTransferError.malformed("iterations out of range")` for anything
+outside. Also clamp `salt.count` to `8…64` bytes (current code accepts any
+length).
+
+## 3. `"SHA256:UNAVAILABLE"` sentinel guard
+
+**File:** `SSH TunnelBuilder/Classes/SSHManager.swift:213, 224`
+
+If `serialize(key:)` returns nil, `fingerprint` falls back to the literal
+`"SHA256:UNAVAILABLE"` string. Today no code path persists that literal into
+`knownHostKey` (the pre-fix bug stored `""`, not the sentinel), so this is not
+exploitable on current data. But the comparison `knownHostKey == fingerprint`
+has no defensive sentinel check — if any future NIOSSH host-key type breaks
+`serialize()` and any other code path ever wrote that literal, the comparison
+silently trusts any host that triggers the nil-serialize path.
+
+**Fix:** in `handleHostKeyValidation`, skip the comparison branch entirely
+when `keyData == nil` (i.e. when `fingerprint == "SHA256:UNAVAILABLE"`).
+Two-line change: gate both equality checks on `keyData != nil`, or early-return
+`isMismatch = true` so the user re-confirms instead of auto-trusting.
+
+## 4. Drop blanket `privacy: .public` on log messages
+
+**File:** `SSH TunnelBuilder/Classes/Logger.swift:23, 27, 31`
+
+Every log level forces `\(message, privacy: .public)`. Call sites interpolate
+SSH server hostnames, tunnel target hosts, and connection nicknames — all of
+which end up in the unified log buffer and any `sysdiagnose` tarball the user
+shares with Apple, IT, or vendor support. No passwords or key material are
+logged anywhere (verified via repo-wide grep), but the operational metadata is
+the user's private/corporate inventory and shouldn't ship verbatim.
+
+**Fix:** drop the blanket `.public` annotation in `Logger.debug` / `.info` /
+`.error`. The os.log default (`.private`) shows full values to a developer
+attached via Xcode but redacts them to `<private>` in archived logs. Touched
+call sites that genuinely need a public correlator can switch to interpolation
+with `privacy: .public` at the use site (preferring `.private(mask: .hash)`
+where a stable but non-reversible marker is enough).
+
+Specific call sites that interpolate sensitive metadata into the format string —
+worth a follow-up audit even after the central fix:
+
+- `SSHManager.swift:183` — error description on connect failure (may embed `host:port`)
+- `SSHManager.swift:333` — `tunnelInfo.remoteServer:remotePort` + originator
+- `SSHManager.swift:358` — forwarding-channel failure with remote target
+- `ConnectionStore.swift:453, 455, 459` — `connection.connectionInfo.name`
+
+## 5. Clear `knownHostKey` on import
+
+**File:** `SSH TunnelBuilder/Classes/ConnectionStore.swift:864`
+
+`importConnections(from:)` copies the imported `knownHostKey` verbatim into the
+new `ConnectionInfo`. Because the SSH client treats any non-empty
+`knownHostKey` as a previously trusted user pin, a malicious `.sshtunnels`
+bundle can quietly pre-pin a host key the attacker controls — and on first
+connect to that hostname the TOFU prompt is silently skipped.
+
+The threat model here is narrow (the import is a full secrets backup, so an
+attacker who can deliver a malicious bundle and persuade the user to open it
+already controls everything inside it), but the silent TOFU bypass violates a
+documented user-facing security promise.
+
+**Fix:** in `importConnections`, force `knownHostKey: ""` so the user sees the
+TOFU fingerprint prompt on first connect to each imported host. One-line change.
+
+---
+
+## Verification plan
+
+- Build the project: zero warnings, zero errors.
+- The existing test suite (currently blocked by the Swift Testing runner bug on
+  the beta toolchain — see `CLAUDE.md`) is not relied on for verification.
+  Where possible, behavioural checks are done in place via `XcodeRefreshCodeIssuesInFile`.


### PR DESCRIPTION
## Summary

Five independent hardening items surfaced by the 2026-06-17 whole-app security audit. None rose to a reportable vulnerability under a strict false-positive filter, but each is worth landing before App Store submission. Per-item rationale lives in `security_hardening.md`.

- **PEMDecryptor.ASN1Parser.readAny** — fix slice expression. Long-form lengths previously produced `data[(offset-2-length)..<(offset+length)]`, which underflows into a Swift bounds-check trap on any encoded value where `length > offset - 2`. Reachable from `decryptEncryptedPKCS8PEM` via the PBES2 PRF `parameters` field and the trailing-data drain. Now matches the existing `readOID`/`readInteger` slice pattern.
- **ConnectionTransfer.decrypt** — clamp envelope `iterations` to `100_000…10_000_000` and `salt.count` to `8…64` *before* running the (slow) KDF. Prevents `UInt32(...)` overflow trap on a hostile `.sshtunnels` and rejects obviously-broken envelopes.
- **SSHManager.handleHostKeyValidation** — gate both pin-match branches on `keyData != nil`. The `"SHA256:UNAVAILABLE"` sentinel returned by `serialize(key:)` on the nil path is non-host-specific, so an inadvertent persisted match value could have auto-trusted any host that triggered the same path. No legacy data is known to be in that state today, but the guard closes the tail risk if a future NIOSSH host-key type ever breaks `serialize()`.
- **Logger** — drop blanket `privacy: .public` on every log level. os.log default (`.private`) now redacts interpolated values in archived logs / `sysdiagnose` / Console.app for other accounts, while a developer attached via Xcode still sees full values. No passwords or key material were ever logged (verified by repo-wide grep); the gain is keeping SSH hostnames and connection nicknames out of diagnostic uploads.
- **ConnectionStore.importConnections** — force `knownHostKey: ""` on every imported connection. A non-empty `knownHostKey` short-circuits the TOFU prompt on first connect, so honouring one from an untrusted bundle would let the bundle author silently pre-pin a key they control. Now the real server fingerprint is shown on first connect to each imported host.

## Verification

- Full `BuildProject` is clean (no errors, no warnings).
- Per-file `XcodeRefreshCodeIssuesInFile` clean for each edited file.
- Existing test suite not relied on (still blocked by the Swift Testing runner bug on the macOS 27 beta toolchain — see CLAUDE.md).

## Test plan

- [ ] Open a malformed encrypted PKCS#8 PEM with a long-form length on the PBKDF2 PRF parameters field via the credentials sheet — confirm the app surfaces a parse error rather than aborting.
- [ ] Craft a `.sshtunnels` with \`iterations: -1\` and another with \`iterations: 50000\` — both should fail import with a friendly malformed-file error before any KDF runs.
- [ ] Import a `.sshtunnels` whose `knownHostKey` is a real OpenSSH wire blob — first connect to the imported host must show the TOFU Unknown Host prompt, not silently succeed.
- [ ] Confirm normal connect / disconnect flows still write expected entries to Console.app when Xcode is attached; verify they appear as \`<private>\` in \`log show\` from a separate user.
- [ ] Host-key validation: existing connections with a previously trusted pin still skip the prompt; new hosts still TOFU; rotated keys still surface the Trust New Key sheet.

## Notes

- Two of the edited files (`ConnectionTransfer.swift`, `Logger.swift`) inherited a stray `+x` mode bit from the working-tree chmod noise documented in \`git status\` on Development. Those mode flips are *not* introduced by this PR — they were already present before any code change. A follow-up housekeeping pass should revert the chmod on every affected path before tagging a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)