### PR TITLE
refactor: silence SonarCloud S1172 and S1186 noise

### DIFF
--- a/SSH TunnelBuilder/Classes/ConnectionStore.swift
+++ b/SSH TunnelBuilder/Classes/ConnectionStore.swift
@@ -41,9 +41,9 @@ private struct UnconfiguredDatabase: ConnectionDatabase {
         NSError(domain: "ConnectionStore.UnconfiguredDatabase", code: 0,
                 userInfo: [NSLocalizedDescriptionKey: "no ConnectionDatabase configured"])
     }
-    func save(_ record: CKRecord) async throws -> CKRecord { throw Self.fail() }
-    func record(for recordID: CKRecord.ID) async throws -> CKRecord { throw Self.fail() }
-    func deleteRecord(withID recordID: CKRecord.ID) async throws -> CKRecord.ID { throw Self.fail() }
+    func save(_: CKRecord) async throws -> CKRecord { throw Self.fail() }
+    func record(for _: CKRecord.ID) async throws -> CKRecord { throw Self.fail() }
+    func deleteRecord(withID _: CKRecord.ID) async throws -> CKRecord.ID { throw Self.fail() }
 }
 
 // A wrapper to make error strings identifiable for SwiftUI Alerts

--- a/SSH TunnelBuilder/Classes/KeychainService.swift
+++ b/SSH TunnelBuilder/Classes/KeychainService.swift
@@ -35,12 +35,16 @@ protocol CredentialsStore {
 }
 
 extension CredentialsStore {
-    func setCredentialProtection(enabled: Bool, for ids: [UUID]) {}
+    /// Default no-op: stores without OS-level credential protection (e.g. the
+    /// mock used in tests) have no items to re-key. `KeychainService` overrides.
+    func setCredentialProtection(enabled _: Bool, for _: [UUID]) {
+        // Intentionally empty — no-op default for stores without OS-level protection.
+    }
 
     /// Default: read each secret independently. Stores without OS-level
     /// authentication (e.g. the mock) don't prompt, so the context is ignored.
     /// `KeychainService` overrides this to read with the authenticated context.
-    func loadCredentials(for id: UUID, authenticatedContext: LAContext?) -> (password: String?, privateKey: String?) {
+    func loadCredentials(for id: UUID, authenticatedContext _: LAContext?) -> (password: String?, privateKey: String?) {
         (loadPassword(for: id), loadPrivateKey(for: id))
     }
 }
@@ -58,7 +62,10 @@ enum CredentialAccount {
 
 final class KeychainService: CredentialsStore, Sendable {
     static let shared = KeychainService()
-    private init() {}
+    private init() {
+        // Singleton: prevent external instantiation. No initialization state to set up —
+        // service identifier is a constant, and Keychain access is performed lazily.
+    }
 
     private let service = "SSH Tunnel Manager"
 
@@ -126,7 +133,7 @@ final class KeychainService: CredentialsStore, Sendable {
     /// The `enabled` parameter is accepted for source compatibility with the
     /// old toggle-driven re-key call site but no longer affects how items are
     /// stored — they are always stored without `.userPresence`.
-    func setCredentialProtection(enabled: Bool, for ids: [UUID]) {
+    func setCredentialProtection(enabled _: Bool, for ids: [UUID]) {
         let context = makeAuthContext(
             reason: "Authenticate to unlock your saved SSH credentials.",
             reuseDuration: 30

--- a/SSH TunnelBuilder/Classes/SSHChannelHandlers.swift
+++ b/SSH TunnelBuilder/Classes/SSHChannelHandlers.swift
@@ -100,7 +100,7 @@ final class GenericRelayHandler<InboundType, OutboundType: Sendable>: ChannelInb
         self.transform = transform
     }
 
-    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+    func channelRead(context _: ChannelHandlerContext, data: NIOAny) {
         let inboundData = self.unwrapInboundIn(data)
         let (outboundData, count) = transform(inboundData)
 

--- a/SSH TunnelBuilder/Classes/SSHManager.swift
+++ b/SSH TunnelBuilder/Classes/SSHManager.swift
@@ -199,7 +199,7 @@ final class SSHManager: @unchecked Sendable {
 
     // MARK: - Host Key Validation
 
-    private func handleHostKeyValidation(host: String, port: Int, key: NIOSSHPublicKey, promise: EventLoopPromise<Void>, knownHostKey: String) {
+    private func handleHostKeyValidation(host: String, port _: Int, key: NIOSSHPublicKey, promise: EventLoopPromise<Void>, knownHostKey: String) {
         let keyData = serialize(key: key)
         let fingerprint: String
         if let keyData = keyData {

--- a/SSH TunnelBuilderTests/SSH_TunnelBuilderTests.swift
+++ b/SSH TunnelBuilderTests/SSH_TunnelBuilderTests.swift
@@ -886,10 +886,10 @@ struct HostKeyRequestTests {
     func isMismatchFlagPreserved() {
         let mismatch = HostKeyRequest(hostname: "h", fingerprint: "f",
                                       keyData: Data([0x01]), isMismatch: true,
-                                      completion: { _ in })
+                                      completion: { _ in /* test only inspects isMismatch */ })
         let firstUse = HostKeyRequest(hostname: "h", fingerprint: "f",
                                       keyData: Data([0x01]), isMismatch: false,
-                                      completion: { _ in })
+                                      completion: { _ in /* test only inspects isMismatch */ })
         #expect(mismatch.isMismatch == true)
         #expect(firstUse.isMismatch == false)
     }


### PR DESCRIPTION
## Summary

Mechanical Sonar-cleanup pass for `swift:S1172` (unused parameter) and `swift:S1186` (empty body). Each touched parameter is either (a) protocol-mandated, so renaming to `_` is the only legitimate fix, or (b) kept in the public signature for source-compat with existing call sites. Each empty body is intentional — singleton init, protocol no-op default, or assertion-only test closure — and now carries a one-line explanation.

The four `swift:S3087` "closure nesting >2" issues are being closed via SonarCloud's API as won't-fix in a separate step. They sit on NIO future chains (`SSHManager`) and CommonCrypto pointer-scoping (`PEMDecryptor`) — refactoring them either requires unsafe pointer manipulation or named helper extraction that just shuffles the same nesting around behind a function call. Sonar's heuristic counts these as code smells; in idiomatic Swift+NIO they're correctness scaffolding.

## What changes

`swift:S1172` (9 sites, all `→ _`):
- `ConnectionStore.swift:44-46` — `UnconfiguredDatabase` `ConnectionDatabase` stubs.
- `KeychainService.swift:38` — `setCredentialProtection` no-op default (CredentialsStore extension).
- `KeychainService.swift:43` — `loadCredentials` default impl ignores `authenticatedContext` (mock stores never prompt).
- `KeychainService.swift:129` — real impl's `enabled` kept on signature for source-compat with the old toggle call sites.
- `SSHManager.swift:202` — `handleHostKeyValidation`'s `port` is irrelevant; the fingerprint compare is host+key scoped.
- `SSHChannelHandlers.swift:103` — `channelRead(context:data:)` `context` required by NIO `ChannelInboundHandler`.

`swift:S1186` (4 sites, one-line comments added):
- `KeychainService.swift:38` — protocol no-op default; "Intentionally empty — no-op default…".
- `KeychainService.swift:61` — singleton `private init()`; explains nothing needs initialization.
- `SSH_TunnelBuilderTests.swift:889/892` — `HostKeyRequest.completion` stubs; explains the assertion only inspects `isMismatch`.

## Test plan

- [x] `BuildProject` clean post-commit.
- [ ] Next SonarCloud scan against `Development` shows 0 open `swift:S1172` and 0 open `swift:S1186` issues (down from 9 and 4).
- [ ] No behavioural change — all renamed parameters were already discarded; comments are inert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)