### PR TITLE
test: move S1186 closure comment into the body as a line statement

### DIFF
--- a/SSH TunnelBuilderTests/SSH_TunnelBuilderTests.swift
+++ b/SSH TunnelBuilderTests/SSH_TunnelBuilderTests.swift
@@ -892,10 +892,16 @@ struct HostKeyRequestTests {
     func isMismatchFlagPreserved() {
         let mismatch = HostKeyRequest(hostname: "h", fingerprint: "f",
                                       keyData: Data([0x01]), isMismatch: true,
-                                      completion: { _ in /* test only inspects isMismatch */ })
+                                      completion: { _ in
+            // Intentionally empty: this test only asserts on the isMismatch flag,
+            // it never invokes completion.
+        })
         let firstUse = HostKeyRequest(hostname: "h", fingerprint: "f",
                                       keyData: Data([0x01]), isMismatch: false,
-                                      completion: { _ in /* test only inspects isMismatch */ })
+                                      completion: { _ in
+            // Intentionally empty: this test only asserts on the isMismatch flag,
+            // it never invokes completion.
+        })
         #expect(mismatch.isMismatch == true)
         #expect(firstUse.isMismatch == false)
     }


### PR DESCRIPTION
## Summary

Follow-up to PR #80. SonarCloud's `swift:S1186` (currently at lines 895/898 in `SSH_TunnelBuilderTests.swift`) still fires on the two `HostKeyRequest` test closures even though PR #80 added an inline `/* … */` annotation, because the comment sits *between* `_ in` and the closing brace — Sonar parses that as a trailing expression comment rather than a body statement.

Reformat both closures to multi-line bodies with the explanation on its own line as a `//` line comment inside the body, which is the form Sonar's rule message asks for ("nested comment explaining why this closure is empty").

## Test plan

- [x] `BuildProject` clean.
- [ ] Next SonarCloud scan against `Development` shows 0 open issues (closes the last two `swift:S1186` reports).

🤖 Generated with [Claude Code](https://claude.com/claude-code)