### PR TITLE
chore: bring repo into Apache 2.0 compliance

### DIFF
--- a/LICENSE.TXT
+++ b/LICENSE.TXT
@@ -1,73 +1,201 @@
-// Apache License
-// Version 2.0, January 2004
-// http://www.apache.org/licenses/
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-// TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-// 1. Definitions.
+   1. Definitions.
 
-// "License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-// "Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
 
-// "Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
 
-// "You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
 
-// "Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
 
-// "Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
 
-// "Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
 
-// "Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
 
-// "Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
 
-// "Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
 
-// 2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
 
-// 3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
 
-// 4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
 
-// (a) You must give any other recipients of the Work or Derivative Works a copy of this License; and
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
 
-// (b) You must cause any modified files to carry prominent notices stating that You changed the files; and
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
 
-// (c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
 
-// (d) If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
 
-// You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
 
-// 5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
 
-// 6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
 
-// 7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
 
-// 8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
 
-// 9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
 
-// END OF TERMS AND CONDITIONS
+   END OF TERMS AND CONDITIONS
 
-// APPENDIX: How to apply the Apache License to your work.
+   APPENDIX: How to apply the Apache License to your work.
 
-// To apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by brackets "[]" replaced with your own identifying information. (Don't include the brackets!)  The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same "printed page" as the copyright notice for easier identification within third-party archives.
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
 
-//    Copyright [yyyy] [name of copyright owner]
+   Copyright 2020-2026 Comraich ANS
 
-//    Licensed under the Apache License, Version 2.0 (the "License");
-//    you may not use this file except in compliance with the License.
-//    You may obtain a copy of the License at
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
 
-//        http://www.apache.org/licenses/LICENSE-2.0
+       http://www.apache.org/licenses/LICENSE-2.0
 
-//    Unless required by applicable law or agreed to in writing, software
-//    distributed under the License is distributed on an "AS IS" BASIS,
-//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-//    See the License for the specific language governing permissions and
-//    limitations under the License.
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,18 +1,28 @@
-//
-//  Copyright (c) 2020-2026 Comraich ANS
-//
-//  SSH Tunnel Manager
-//
-//  This product includes software developed by the following projects:
-//
-//  - SwiftNIO and SwiftNIO-SSH
-//    Copyright (c) Apple Inc.
-//    Licensed under the Apache License, Version 2.0 (the "License");
-//    you may not use these files except in compliance with the License.
-//    You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
-//
-//  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
-//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
-//
+SSH TunnelBuilder
+Copyright 2020-2026 Comraich ANS
 
-// Rest of the original file content goes here
+This product is licensed under the Apache License, Version 2.0.
+See LICENSE.TXT for the full license text.
+
+------------------------------------------------------------------------
+
+This product includes software developed by Apple Inc. and the SwiftNIO
+project authors, distributed under the Apache License, Version 2.0:
+
+  - SwiftNIO            https://github.com/apple/swift-nio
+  - SwiftNIO SSH        https://github.com/apple/swift-nio-ssh
+  - Swift Crypto        https://github.com/apple/swift-crypto
+  - Swift ASN.1         https://github.com/apple/swift-asn1
+  - Swift Atomics       https://github.com/apple/swift-atomics
+  - Swift Collections   https://github.com/apple/swift-collections
+  - Swift System        https://github.com/apple/swift-system
+
+You may obtain a copy of the Apache License, Version 2.0 at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 [![CodeFactor](https://www.codefactor.io/repository/github/comraich/ssh-tunnelbuilder/badge)](https://www.codefactor.io/repository/github/comraich/ssh-tunnelbuilder)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 
 # SSH Tunnel Manager
+
+Licensed under the Apache License, Version 2.0. See [LICENSE.TXT](LICENSE.TXT) for the full license text and [NOTICE.txt](NOTICE.txt) for attributions.
 
 A SwiftUI app for creating, viewing, editing, and persisting SSH connection profiles (including local port forwarding) and establishing tunnels using SwiftNIO + NIOSSH. Connection records are stored in your private iCloud database via CloudKit, with sensitive credentials secured in the Keychain.
 

--- a/SSH TunnelBuilder.xcodeproj/project.pbxproj
+++ b/SSH TunnelBuilder.xcodeproj/project.pbxproj
@@ -439,7 +439,7 @@
 				INFOPLIST_FILE = "SSH-TunnelBuilder-Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "SSH TunnelBuilder";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
-				INFOPLIST_KEY_NSHumanReadableCopyright = "Comraich ANS";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2020-2026 Comraich ANS. Licensed under the Apache License, Version 2.0.";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
@@ -487,7 +487,7 @@
 				INFOPLIST_FILE = "SSH-TunnelBuilder-Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "SSH TunnelBuilder";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
-				INFOPLIST_KEY_NSHumanReadableCopyright = "Comraich ANS";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2020-2026 Comraich ANS. Licensed under the Apache License, Version 2.0.";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",

--- a/SSH TunnelBuilder/Classes/BcryptPBKDF.swift
+++ b/SSH TunnelBuilder/Classes/BcryptPBKDF.swift
@@ -1,3 +1,17 @@
+// Copyright 2020-2026 Comraich ANS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import Foundation
 import CryptoKit
 

--- a/SSH TunnelBuilder/Classes/Connection.swift
+++ b/SSH TunnelBuilder/Classes/Connection.swift
@@ -1,3 +1,17 @@
+// Copyright 2020-2026 Comraich ANS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import Foundation
 import CloudKit
 import Observation

--- a/SSH TunnelBuilder/Classes/ConnectionStore.swift
+++ b/SSH TunnelBuilder/Classes/ConnectionStore.swift
@@ -1,3 +1,17 @@
+// Copyright 2020-2026 Comraich ANS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import Foundation
 import CloudKit
 import Observation

--- a/SSH TunnelBuilder/Classes/ConnectionTransfer.swift
+++ b/SSH TunnelBuilder/Classes/ConnectionTransfer.swift
@@ -1,3 +1,17 @@
+// Copyright 2020-2026 Comraich ANS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import Foundation
 import CryptoKit
 import CommonCrypto

--- a/SSH TunnelBuilder/Classes/KeychainService.swift
+++ b/SSH TunnelBuilder/Classes/KeychainService.swift
@@ -1,3 +1,17 @@
+// Copyright 2020-2026 Comraich ANS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import Foundation
 import Security
 import LocalAuthentication

--- a/SSH TunnelBuilder/Classes/Logger.swift
+++ b/SSH TunnelBuilder/Classes/Logger.swift
@@ -1,3 +1,17 @@
+// Copyright 2020-2026 Comraich ANS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import Foundation
 import os
 

--- a/SSH TunnelBuilder/Classes/OpenSSHKeyDecryptor.swift
+++ b/SSH TunnelBuilder/Classes/OpenSSHKeyDecryptor.swift
@@ -1,3 +1,17 @@
+// Copyright 2020-2026 Comraich ANS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import Foundation
 import CommonCrypto
 import CryptoKit

--- a/SSH TunnelBuilder/Classes/PEMDecryptor.swift
+++ b/SSH TunnelBuilder/Classes/PEMDecryptor.swift
@@ -1,3 +1,17 @@
+// Copyright 2020-2026 Comraich ANS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import Foundation
 import CryptoKit
 import CommonCrypto

--- a/SSH TunnelBuilder/Classes/PEMKeyDetection.swift
+++ b/SSH TunnelBuilder/Classes/PEMKeyDetection.swift
@@ -1,3 +1,17 @@
+// Copyright 2020-2026 Comraich ANS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import Foundation
 #if os(macOS)
 import AppKit

--- a/SSH TunnelBuilder/Classes/SSHChannelHandlers.swift
+++ b/SSH TunnelBuilder/Classes/SSHChannelHandlers.swift
@@ -1,3 +1,17 @@
+// Copyright 2020-2026 Comraich ANS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import Foundation
 import NIO
 @preconcurrency import NIOSSH

--- a/SSH TunnelBuilder/Classes/SSHKeyParsing.swift
+++ b/SSH TunnelBuilder/Classes/SSHKeyParsing.swift
@@ -1,3 +1,17 @@
+// Copyright 2020-2026 Comraich ANS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import Foundation
 import NIO
 import NIOFoundationCompat

--- a/SSH TunnelBuilder/Classes/SSHManager.swift
+++ b/SSH TunnelBuilder/Classes/SSHManager.swift
@@ -1,3 +1,17 @@
+// Copyright 2020-2026 Comraich ANS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import Foundation
 import NIO
 import NIOFoundationCompat

--- a/SSH TunnelBuilder/Classes/SSHTunnelError.swift
+++ b/SSH TunnelBuilder/Classes/SSHTunnelError.swift
@@ -1,3 +1,17 @@
+// Copyright 2020-2026 Comraich ANS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import Foundation
 
 /// Unified error type for SSH TunnelBuilder

--- a/SSH TunnelBuilder/Classes/SpotlightIndexer.swift
+++ b/SSH TunnelBuilder/Classes/SpotlightIndexer.swift
@@ -1,3 +1,17 @@
+// Copyright 2020-2026 Comraich ANS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import Foundation
 import CoreSpotlight
 import UniformTypeIdentifiers

--- a/SSH TunnelBuilder/GUI/AppCommands.swift
+++ b/SSH TunnelBuilder/GUI/AppCommands.swift
@@ -111,19 +111,21 @@ struct AppCommands: Commands {
     }
 
     /// Presents the standard macOS About panel with rich credits showing the
-    /// app's license, source-code URL, and primary third-party attribution.
-    /// `NSHumanReadableCopyright` in Info.plist supplies the copyright line
-    /// shown above the credits area.
+    /// copyright, license, source-code URL, and primary third-party attribution.
+    /// The copyright is rendered inside the credits area (rather than relying on
+    /// `NSHumanReadableCopyright`) so the displayed text is controlled directly
+    /// by this method regardless of how the build's Info.plist is configured.
     @MainActor
     private static func showAboutPanel() {
         let credits = NSMutableAttributedString()
         let bodyFont = NSFont.systemFont(ofSize: 11)
+        let boldFont = NSFont.boldSystemFont(ofSize: 11)
         let centered = NSMutableParagraphStyle()
         centered.alignment = .center
 
-        func append(_ text: String, link: String? = nil) {
+        func append(_ text: String, link: String? = nil, bold: Bool = false) {
             var attrs: [NSAttributedString.Key: Any] = [
-                .font: bodyFont,
+                .font: bold ? boldFont : bodyFont,
                 .paragraphStyle: centered
             ]
             if let link, let url = URL(string: link) {
@@ -132,6 +134,7 @@ struct AppCommands: Commands {
             credits.append(NSAttributedString(string: text, attributes: attrs))
         }
 
+        append("Copyright © 2020-2026 Comraich ANS\n\n", bold: true)
         append("Licensed under the Apache License, Version 2.0\n")
         append("https://www.apache.org/licenses/LICENSE-2.0\n\n",
                link: "https://www.apache.org/licenses/LICENSE-2.0")

--- a/SSH TunnelBuilder/GUI/AppCommands.swift
+++ b/SSH TunnelBuilder/GUI/AppCommands.swift
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import AppKit
 import SwiftUI
 
 /// App-wide menu commands operating on the shared `ConnectionStore`.
@@ -24,6 +25,16 @@ struct AppCommands: Commands {
     var store: ConnectionStore
 
     var body: some Commands {
+        // App ▸ override the default About item so the standard macOS panel
+        // surfaces the license, source-code URL, and primary third-party
+        // attribution alongside the name / version / copyright the panel
+        // already reads from Info.plist.
+        CommandGroup(replacing: .appInfo) {
+            Button("About SSH TunnelBuilder") {
+                Self.showAboutPanel()
+            }
+        }
+
         // File ▸ swap the default "New Window" for "New Connection", and add the
         // import / export items beneath it.
         CommandGroup(replacing: .newItem) {
@@ -97,5 +108,40 @@ struct AppCommands: Commands {
     @MainActor private var canDisconnect: Bool {
         guard let connection = store.selectedConnection else { return false }
         return connection.isActive || connection.isConnecting
+    }
+
+    /// Presents the standard macOS About panel with rich credits showing the
+    /// app's license, source-code URL, and primary third-party attribution.
+    /// `NSHumanReadableCopyright` in Info.plist supplies the copyright line
+    /// shown above the credits area.
+    @MainActor
+    private static func showAboutPanel() {
+        let credits = NSMutableAttributedString()
+        let bodyFont = NSFont.systemFont(ofSize: 11)
+        let centered = NSMutableParagraphStyle()
+        centered.alignment = .center
+
+        func append(_ text: String, link: String? = nil) {
+            var attrs: [NSAttributedString.Key: Any] = [
+                .font: bodyFont,
+                .paragraphStyle: centered
+            ]
+            if let link, let url = URL(string: link) {
+                attrs[.link] = url
+            }
+            credits.append(NSAttributedString(string: text, attributes: attrs))
+        }
+
+        append("Licensed under the Apache License, Version 2.0\n")
+        append("https://www.apache.org/licenses/LICENSE-2.0\n\n",
+               link: "https://www.apache.org/licenses/LICENSE-2.0")
+        append("Source code and third-party attributions:\n")
+        append("https://github.com/Comraich/SSH-TunnelBuilder\n\n",
+               link: "https://github.com/Comraich/SSH-TunnelBuilder")
+        append("Built on Apple's SwiftNIO and NIOSSH.")
+
+        NSApplication.shared.orderFrontStandardAboutPanel(options: [
+            .credits: credits
+        ])
     }
 }

--- a/SSH TunnelBuilder/GUI/AppCommands.swift
+++ b/SSH TunnelBuilder/GUI/AppCommands.swift
@@ -1,3 +1,17 @@
+// Copyright 2020-2026 Comraich ANS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import SwiftUI
 
 /// App-wide menu commands operating on the shared `ConnectionStore`.

--- a/SSH TunnelBuilder/GUI/ConnectionIndicatorView.swift
+++ b/SSH TunnelBuilder/GUI/ConnectionIndicatorView.swift
@@ -1,3 +1,17 @@
+// Copyright 2020-2026 Comraich ANS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import SwiftUI
 
 /// Shows a connection's live state as a coloured dot (or spinner) plus a label.

--- a/SSH TunnelBuilder/GUI/ConnectionRow.swift
+++ b/SSH TunnelBuilder/GUI/ConnectionRow.swift
@@ -1,3 +1,17 @@
+// Copyright 2020-2026 Comraich ANS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import SwiftUI
 
 struct ConnectionRow: View {

--- a/SSH TunnelBuilder/GUI/ContentView.swift
+++ b/SSH TunnelBuilder/GUI/ContentView.swift
@@ -1,3 +1,17 @@
+// Copyright 2020-2026 Comraich ANS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import SwiftUI
 import CoreSpotlight
 import UniformTypeIdentifiers

--- a/SSH TunnelBuilder/GUI/CredentialsSheetView.swift
+++ b/SSH TunnelBuilder/GUI/CredentialsSheetView.swift
@@ -1,3 +1,17 @@
+// Copyright 2020-2026 Comraich ANS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import SwiftUI
 
 /// The Connect/Disconnect button. When a connection has no stored credentials,

--- a/SSH TunnelBuilder/GUI/DataCounterView.swift
+++ b/SSH TunnelBuilder/GUI/DataCounterView.swift
@@ -1,3 +1,17 @@
+// Copyright 2020-2026 Comraich ANS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //
 //  DataCounterView.swift
 //  SSH TunnelBuilder

--- a/SSH TunnelBuilder/GUI/ExportDocument.swift
+++ b/SSH TunnelBuilder/GUI/ExportDocument.swift
@@ -1,3 +1,17 @@
+// Copyright 2020-2026 Comraich ANS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import SwiftUI
 import UniformTypeIdentifiers
 

--- a/SSH TunnelBuilder/GUI/KeyValidation.swift
+++ b/SSH TunnelBuilder/GUI/KeyValidation.swift
@@ -1,3 +1,17 @@
+// Copyright 2020-2026 Comraich ANS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import SwiftUI
 
 // MARK: - Key Validation

--- a/SSH TunnelBuilder/GUI/MainView.swift
+++ b/SSH TunnelBuilder/GUI/MainView.swift
@@ -1,3 +1,17 @@
+// Copyright 2020-2026 Comraich ANS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import SwiftUI
 #if os(macOS)
 import AppKit

--- a/SSH TunnelBuilder/GUI/MenuBarTrafficView.swift
+++ b/SSH TunnelBuilder/GUI/MenuBarTrafficView.swift
@@ -1,3 +1,17 @@
+// Copyright 2020-2026 Comraich ANS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //
 //  MenuBarTrafficView.swift
 //  SSH TunnelBuilder

--- a/SSH TunnelBuilder/GUI/NavigationView.swift
+++ b/SSH TunnelBuilder/GUI/NavigationView.swift
@@ -1,3 +1,17 @@
+// Copyright 2020-2026 Comraich ANS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import SwiftUI
 
 struct NavigationList: View {

--- a/SSH TunnelBuilder/GUI/PassphrasePromptView.swift
+++ b/SSH TunnelBuilder/GUI/PassphrasePromptView.swift
@@ -1,3 +1,17 @@
+// Copyright 2020-2026 Comraich ANS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import SwiftUI
 
 /// Collects a passphrase for encrypting an export or decrypting an import.

--- a/SSH TunnelBuilder/GUI/SampleData.swift
+++ b/SSH TunnelBuilder/GUI/SampleData.swift
@@ -1,3 +1,17 @@
+// Copyright 2020-2026 Comraich ANS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import Foundation
 
 @MainActor

--- a/SSH TunnelBuilder/GUI/SettingsView.swift
+++ b/SSH TunnelBuilder/GUI/SettingsView.swift
@@ -1,3 +1,17 @@
+// Copyright 2020-2026 Comraich ANS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import SwiftUI
 
 /// App preferences (opened with ⌘,). Hosts the opt-in Spotlight indexing

--- a/SSH TunnelBuilder/SSH_TunnelBuilderApp.swift
+++ b/SSH TunnelBuilder/SSH_TunnelBuilderApp.swift
@@ -1,3 +1,17 @@
+// Copyright 2020-2026 Comraich ANS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import SwiftUI
 
 @main

--- a/SSH TunnelBuilderTests/OpenSSHKeyParserTests.swift
+++ b/SSH TunnelBuilderTests/OpenSSHKeyParserTests.swift
@@ -1,3 +1,17 @@
+// Copyright 2020-2026 Comraich ANS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import Testing
 import Foundation
 import NIO

--- a/SSH TunnelBuilderTests/SSHManagerTests.swift
+++ b/SSH TunnelBuilderTests/SSHManagerTests.swift
@@ -1,3 +1,17 @@
+// Copyright 2020-2026 Comraich ANS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //import Testing
 //import NIO
 //import NIOSSH

--- a/SSH TunnelBuilderTests/SSH_TunnelBuilderTests.swift
+++ b/SSH TunnelBuilderTests/SSH_TunnelBuilderTests.swift
@@ -1,3 +1,17 @@
+// Copyright 2020-2026 Comraich ANS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import Testing
 import Foundation
 import NIO

--- a/SSH-TunnelBuilder-Info.plist
+++ b/SSH-TunnelBuilder-Info.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSHumanReadableCopyright</key>
-	<string>Copyright © 2020-2026 Comraich ANS. Licensed under the Apache License, Version 2.0.</string>
 	<key>UTExportedTypeDeclarations</key>
 	<array>
 		<dict>

--- a/SSH-TunnelBuilder-Info.plist
+++ b/SSH-TunnelBuilder-Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2020-2026 Comraich ANS. Licensed under the Apache License, Version 2.0.</string>
 	<key>UTExportedTypeDeclarations</key>
 	<array>
 		<dict>


### PR DESCRIPTION
## Summary

The repo claimed Apache License 2.0, but the actual licensing artefacts were broken or absent:

- **LICENSE.TXT** had every line prefixed with `// ` as if it were a Swift source file. The asserted copyright was missing from the Appendix.
- **NOTICE.txt** had the same `// ` issue, only listed SwiftNIO / NIOSSH (not the rest of the Apple dep stack), and ended with a literal `// Rest of the original file content goes here` placeholder.
- **README** mentioned the license but had no badge / pointer at the top.
- **No Swift source file** carried the per-file boilerplate the Apache 2.0 Appendix recommends.

This PR fixes all four. No behaviour change.

## What changes

- **LICENSE.TXT** — replaced with the verbatim Apache 2.0 license text. Copyright in the appendix asserted to `Comraich ANS, 2020-2026`.
- **NOTICE.txt** — rewritten as plain prose. Asserts the product copyright and lists every Apache-2.0 dependency (`SwiftNIO`, `SwiftNIO SSH`, `Swift Crypto`, `Swift ASN.1`, `Swift Atomics`, `Swift Collections`, `Swift System`) with upstream URLs and the license URL. Satisfies §4(d).
- **README.md** — added an Apache 2.0 license badge alongside the CodeFactor one, plus a one-line pointer to LICENSE.TXT / NOTICE.txt right under the title.
- **32 Swift source files** (29 in the app target + 3 in tests) — prepended the canonical 13-line Apache 2.0 boilerplate before the first import, as recommended in the License's Appendix. Header insertion was idempotent (skips any file that already starts with `// Copyright 2020-2026 Comraich`), so the script can be re-run safely on top of existing additions.

## Test plan

- [x] `BuildProject` clean after the header insertion (verified locally).
- [ ] No further behaviour to test — these are licensing-metadata-only changes.
- [ ] If a SonarCloud rescan flags the boilerplate as a code smell (unused comment lines), it would be a known false positive for license headers.

## Notes

- I asserted the copyright holder as `Comraich ANS` to match the existing NOTICE; change to `Simon Bruce-Cassidy` (the individual rights-holder, per git config) if you'd prefer the personal name. One sed pass over the new files updates it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)