### PR TITLE
Fix App Review (Guideline 4): keep app alive when window closes, add reopen paths

### DIFF
--- a/SSH TunnelBuilder/GUI/AppCommands.swift
+++ b/SSH TunnelBuilder/GUI/AppCommands.swift
@@ -9,6 +9,11 @@ import SwiftUI
 struct AppCommands: Commands {
     var store: ConnectionStore
 
+    // `openWindow(id:)` brings the main window back if it has been closed.
+    // SwiftUI's `Window` scene does not always populate the Window menu with a
+    // re-open entry on its own, so we add one explicitly below.
+    @Environment(\.openWindow) private var openWindow
+
     var body: some Commands {
         // File ▸ swap the default "New Window" for "New Connection", and add the
         // import / export items beneath it.
@@ -72,6 +77,18 @@ struct AppCommands: Commands {
             }
             .keyboardShortcut(.delete, modifiers: .command)
             .disabled(store.selectedConnection == nil)
+        }
+
+        // Window ▸ a guaranteed re-open entry. With our single-`Window` scene
+        // and `AppDelegate` keeping the app alive after the window is closed,
+        // this is the canonical macOS way to bring it back from the menu bar.
+        CommandGroup(before: .windowArrangement) {
+            Button("Open main window") {
+                openWindow(id: "main")
+            }
+            .keyboardShortcut("1", modifiers: .command)
+
+            Divider()
         }
     }
 

--- a/SSH TunnelBuilder/GUI/MenuBarTrafficView.swift
+++ b/SSH TunnelBuilder/GUI/MenuBarTrafficView.swift
@@ -131,9 +131,11 @@ struct MenuBarTrafficLabel: View {
 }
 
 /// The dropdown shown when the menu bar item is clicked: one line per connected
-/// tunnel with its cumulative sent/received totals.
+/// tunnel with its cumulative sent/received totals, plus a button to bring the
+/// main window back if it's been closed.
 struct MenuBarTrafficContent: View {
     var store: ConnectionStore
+    @Environment(\.openWindow) private var openWindow
 
     var body: some View {
         let active = store.connections.filter { $0.state.isActive }
@@ -143,6 +145,12 @@ struct MenuBarTrafficContent: View {
             ForEach(active) { connection in
                 Text("\(connection.connectionInfo.name) — ↑ \(connection.bytesSent.formatted(.byteCount(style: .file)))  ↓ \(connection.bytesReceived.formatted(.byteCount(style: .file)))")
             }
+        }
+
+        Divider()
+
+        Button("Show Main Window") {
+            openWindow(id: "main")
         }
     }
 }

--- a/SSH TunnelBuilder/SSH_TunnelBuilderApp.swift
+++ b/SSH TunnelBuilder/SSH_TunnelBuilderApp.swift
@@ -1,7 +1,13 @@
 import SwiftUI
+import AppKit
 
 @main
 struct SSH_TunnelBuilderApp: App {
+    // Keeps the app (and any active tunnels) alive after the window is closed,
+    // and reopens the window on a dock click. Without this, closing the window
+    // terminates the app and tears down every connection — see `AppDelegate`.
+    @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
+
     @State private var connectionStore: ConnectionStore
     @State private var trafficMonitor: MenuBarTrafficMonitor
 
@@ -14,7 +20,11 @@ struct SSH_TunnelBuilderApp: App {
     }
 
     var body: some Scene {
-        WindowGroup {
+        // Single-instance `Window` (not `WindowGroup`) so SwiftUI auto-adds it
+        // to the Window menu — closing the window leaves the entry there, and
+        // the user can reopen it from the menu (or the menu bar item, or the
+        // dock icon).
+        Window("SSH Tunnel Builder", id: "main") {
             ContentView(connectionStore: connectionStore)
         }
         .commands {
@@ -37,5 +47,24 @@ struct SSH_TunnelBuilderApp: App {
         } label: {
             MenuBarTrafficLabel(monitor: trafficMonitor)
         }
+    }
+}
+
+/// Keeps the app running after the user closes the main window so active
+/// tunnels survive, and brings the window back on a dock click.
+///
+/// SwiftUI's `Window` scene treats the close button as "quit the app" by
+/// default (unlike `WindowGroup`), which would tear down every tunnel.
+/// Returning `false` from `applicationShouldTerminateAfterLastWindowClosed`
+/// suppresses that, leaving the dock icon and any active `MenuBarExtra` in
+/// place; `applicationShouldHandleReopen` then lets the system perform its
+/// standard re-show of the main window when the dock icon is clicked.
+final class AppDelegate: NSObject, NSApplicationDelegate {
+    func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
+        false
+    }
+
+    func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows: Bool) -> Bool {
+        true
     }
 }


### PR DESCRIPTION
## Summary

App Review (Submission ID `ced63243-d49e-4520-a4b9-082f67480f3f`, version 2.2 (6)) flagged Guideline 4 — closing the main window left users with no way to bring it back. Investigating revealed a related, more serious bug: the previous `WindowGroup` + replaced `.newItem` configuration stripped every standard reopen path, and naively switching to a `Window` scene terminates the app on close — taking active SSH tunnels with it.

- Replace `WindowGroup` with single-instance `Window(id: "main")`.
- Add `NSApplicationDelegateAdaptor` so closing the window no longer terminates the app — process, dock icon, `MenuBarExtra`, and active tunnels survive. Dock-click reopens the window.
- Add explicit **"Open main window"** entry (⌘1) to the Window menu.
- Add **"Show Main Window"** button to the menu bar item's dropdown.

## Test plan

- [x] Builds cleanly (`BuildProject`).
- [x] Verified live: open a connection, close the window — dock icon stays, menu bar item stays, tunnel keeps flowing.
- [x] Verified live: Window menu ▸ Open main window (⌘1) reopens the window.
- [x] Verified live: dock-icon click reopens the window.
- [x] Verified live: menu bar item ▸ "Show Main Window" reopens the window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)